### PR TITLE
Nest Grok subagent sessions under their parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0] — 2026-08-20
+
+- New: Grok Build subagent sessions nest under their parent in the session list (chevron, or click again when selected)
+- New: deleting a parent session also moves its nested sessions to Trash
+- Fix: Cursor project paths with underscores (e.g. `app_av4`) no longer decode as extra path segments
+- Change: sidebar agent / project / All Sessions counts list top-level rows only; nested children show on the parent row
+
 ## [0.2.1] — 2026-08-20
 
 - Fix: resuming OpenCode sessions in your terminal now works (broken in the 0.2.0 build)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.3.0] — 2026-08-20
 
-- New: Grok Build subagent sessions nest under their parent in the session list (chevron, or click again when selected)
+- New: session list prefers each agent's renamed title (Grok `/rename`, Claude `custom-title`, Codex `thread_name`, Pi session title, …) over the first prompt
 - New: deleting a parent session also moves its nested sessions to Trash
 - Fix: Cursor project paths with underscores (e.g. `app_av4`) no longer decode as extra path segments
 - Change: sidebar agent / project / All Sessions counts list top-level rows only; nested children show on the parent row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.3.0] — 2026-08-20
 
-- New: session list prefers each agent's renamed title (Grok `/rename`, Claude `custom-title`, Codex `thread_name`, Pi session title, …) over the first prompt
+- New: session list prefers each agent's renamed title (Grok `/rename`, Claude `custom-title`, Codex `thread_name`, Cursor IDE title, Pi session title, …) over the first prompt
 - New: deleting a parent session also moves its nested sessions to Trash
 - Fix: Cursor project paths with underscores (e.g. `app_av4`) no longer decode as extra path segments
 - Change: sidebar agent / project / All Sessions counts list top-level rows only; nested children show on the parent row

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "wake"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6795,7 +6795,7 @@ dependencies = [
 
 [[package]]
 name = "wake-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/wake-core", "crates/wake"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Your agent history is scattered across `~/.claude`, `~/.codex`, and nine other p
 ## Features
 
 - **Unified browsing** — all sessions grouped by agent / project, live file watching for incremental updates
+- **Nested Grok sessions** — Grok Build subagents sit under their parent session; expand to browse, delete the parent to trash the tree
 - **Full-text search** (⌘K) — SQLite FTS5 trigram index; handles CJK text and code substrings (like `useEffect(`) equally well; jumps straight to the matched message in the transcript
 - **Transcript view** — per-message rendering with user/assistant bubbles, collapsible tool-call clusters, thinking summaries, tree-sitter code highlighting (30+ languages)
 - **One-click resume** — reopens the session in Terminal/iTerm at the original project directory (`claude --resume`, `codex resume`, …)

--- a/crates/wake-core/src/adapters/claude.rs
+++ b/crates/wake-core/src/adapters/claude.rs
@@ -103,6 +103,10 @@ fn parse_claude_jsonl(path: &Path, include_sidechain: bool) -> Result<ParseResul
     let mut tool_index: HashMap<String, (usize, usize)> = HashMap::new();
     let mut custom_title = String::new();
     let mut fallback_title = String::new();
+    let file_id = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
     let mut cwd = String::new();
     let mut git_branch: Option<String> = None;
     let mut model: Option<String> = None;
@@ -133,6 +137,11 @@ fn parse_claude_jsonl(path: &Path, include_sidechain: bool) -> Result<ParseResul
         let typ = row.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
         if typ == "custom-title" {
+            // /rename 带 sessionId;写进当前文件但指向别的会话时不要抢标题
+            let sid = row.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+            if !sid.is_empty() && sid != file_id {
+                continue;
+            }
             if let Some(t) = row.get("customTitle").and_then(|v| v.as_str()) {
                 if !t.trim().is_empty() {
                     custom_title = t.trim().to_string();
@@ -177,7 +186,12 @@ fn parse_claude_jsonl(path: &Path, include_sidechain: bool) -> Result<ParseResul
             flush_assistant(&mut pending, &mut messages, &mut tool_index);
             let subtype = row.get("subtype").and_then(|v| v.as_str());
             if subtype == Some("compact_boundary") {
-                messages.push(mk_msg(Role::System, MessageKind::CompactSummary, "── Context compacted ──", ts));
+                messages.push(mk_msg(
+                    Role::System,
+                    MessageKind::CompactSummary,
+                    "── Context compacted ──",
+                    ts,
+                ));
             } else if let Some(content) = row.get("content").and_then(|v| v.as_str()) {
                 if !content.is_empty() {
                     let (text, truncated) = clip(content, MAX_TOOL_IO);
@@ -216,7 +230,8 @@ fn parse_claude_jsonl(path: &Path, include_sidechain: bool) -> Result<ParseResul
                             }
                             Some("tool_result") => {
                                 had_tool_result = true;
-                                let id = b.get("tool_use_id").and_then(|v| v.as_str()).unwrap_or("");
+                                let id =
+                                    b.get("tool_use_id").and_then(|v| v.as_str()).unwrap_or("");
                                 if let Some(&(mi, ti)) = tool_index.get(id) {
                                     let out = stringify_tool_result(b.get("content"));
                                     let target = &mut messages[mi].tool_calls[ti];
@@ -295,8 +310,14 @@ fn parse_claude_jsonl(path: &Path, include_sidechain: bool) -> Result<ParseResul
             }
         }
         if let Some(usage) = message.get("usage") {
-            tokens_used += usage.get("input_tokens").and_then(|v| v.as_i64()).unwrap_or(0)
-                + usage.get("output_tokens").and_then(|v| v.as_i64()).unwrap_or(0)
+            tokens_used += usage
+                .get("input_tokens")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0)
+                + usage
+                    .get("output_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0)
                 + usage
                     .get("cache_creation_input_tokens")
                     .and_then(|v| v.as_i64())
@@ -321,10 +342,15 @@ fn parse_claude_jsonl(path: &Path, include_sidechain: bool) -> Result<ParseResul
                             }
                         }
                         Some("tool_use") => {
-                            let id = b.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                            let id = b
+                                .get("id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string();
                             let input = b.get("input").cloned().unwrap_or(Value::Null);
                             let name = b.get("name").and_then(|v| v.as_str()).unwrap_or("tool");
-                            p.tool_calls.push(tool_call_view(id, name, &input, None, false));
+                            p.tool_calls
+                                .push(tool_call_view(id, name, &input, None, false));
                         }
                         _ => {}
                     }
@@ -405,8 +431,16 @@ fn build_meta(r: &SessionFileRef, p: &ParseResult) -> SessionMeta {
         project_path: p.cwd.clone(),
         project_name,
         file_path: r.file_path.clone(),
-        created_at: if p.created_at > 0 { p.created_at } else { r.mtime_ms },
-        updated_at: if p.updated_at > 0 { p.updated_at } else { r.mtime_ms },
+        created_at: if p.created_at > 0 {
+            p.created_at
+        } else {
+            r.mtime_ms
+        },
+        updated_at: if p.updated_at > 0 {
+            p.updated_at
+        } else {
+            r.mtime_ms
+        },
         message_count: p
             .messages
             .iter()
@@ -415,7 +449,11 @@ fn build_meta(r: &SessionFileRef, p: &ParseResult) -> SessionMeta {
         size_bytes: r.size,
         git_branch: p.git_branch.clone(),
         model: p.model.clone(),
-        tokens_used: if p.tokens_used > 0 { Some(p.tokens_used) } else { None },
+        tokens_used: if p.tokens_used > 0 {
+            Some(p.tokens_used)
+        } else {
+            None
+        },
         archived: false,
         source: None,
         favorite: false,
@@ -451,9 +489,18 @@ fn list_sidechains(r: &SessionFileRef) -> Vec<SidechainInfo> {
         };
         if let Ok(meta_raw) = fs::read_to_string(dir.join(format!("{id}.meta.json"))) {
             if let Ok(meta) = serde_json::from_str::<Value>(&meta_raw) {
-                info.agent_type = meta.get("agentType").and_then(|v| v.as_str()).map(String::from);
-                info.description = meta.get("description").and_then(|v| v.as_str()).map(String::from);
-                info.tool_use_id = meta.get("toolUseId").and_then(|v| v.as_str()).map(String::from);
+                info.agent_type = meta
+                    .get("agentType")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                info.description = meta
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                info.tool_use_id = meta
+                    .get("toolUseId")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
             }
         }
         out.push(info);
@@ -536,7 +583,11 @@ impl AgentAdapter for ClaudeAdapter {
         })
     }
 
-    fn load_sidechain(&self, r: &SessionFileRef, sidechain_id: &str) -> Result<Vec<TranscriptMessage>> {
+    fn load_sidechain(
+        &self,
+        r: &SessionFileRef,
+        sidechain_id: &str,
+    ) -> Result<Vec<TranscriptMessage>> {
         let file = subagents_dir(r).join(format!("{sidechain_id}.jsonl"));
         if !file.is_file() {
             return Ok(Vec::new());
@@ -574,4 +625,3 @@ impl AgentAdapter for ClaudeAdapter {
         }
     }
 }
-

--- a/crates/wake-core/src/adapters/codex.rs
+++ b/crates/wake-core/src/adapters/codex.rs
@@ -9,11 +9,15 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 pub struct CodexAdapter {
     sessions_dir: PathBuf,
     archived_dir: PathBuf,
     state_db: PathBuf,
+    /// `/rename` 与 App 改名写在 `session_index.jsonl` 的 thread_name,不是 state DB 的 title
+    index_path: PathBuf,
+    names: Mutex<Option<(i64, HashMap<String, String>)>>,
 }
 
 impl CodexAdapter {
@@ -23,8 +27,63 @@ impl CodexAdapter {
             sessions_dir: root.join("sessions"),
             archived_dir: root.join("archived_sessions"),
             state_db: root.join("state_5.sqlite"),
+            index_path: root.join("session_index.jsonl"),
+            names: Mutex::new(None),
         }
     }
+
+    fn thread_name(&self, id: &str) -> Option<String> {
+        self.thread_names().get(id).cloned()
+    }
+
+    fn thread_names(&self) -> HashMap<String, String> {
+        let mtime = fs::metadata(&self.index_path)
+            .map(|m| mtime_ms(&m))
+            .unwrap_or(0);
+        {
+            let cache = self.names.lock().unwrap();
+            if let Some((t, map)) = cache.as_ref() {
+                if *t == mtime {
+                    return map.clone();
+                }
+            }
+        }
+        let map = read_session_index(&self.index_path);
+        *self.names.lock().unwrap() = Some((mtime, map.clone()));
+        map
+    }
+}
+
+/// Codex App/`/rename` 落在 session_index.jsonl,后写覆盖先写。
+fn read_session_index(path: &Path) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Ok(file) = fs::File::open(path) else {
+        return map;
+    };
+    for line in BufReader::new(file).lines().flatten() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(id) = v
+            .get("id")
+            .and_then(|x| x.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        if let Some(name) = v
+            .get("thread_name")
+            .and_then(|x| x.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            map.insert(id.to_string(), name.to_string());
+        }
+    }
+    map
 }
 
 #[derive(Debug)]
@@ -293,7 +352,10 @@ fn parse_rollout(path: &Path) -> Result<CodexParse> {
                         }
                     }
                     "function_call_output" | "custom_tool_call_output" => {
-                        let call_id = payload.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
+                        let call_id = payload
+                            .get("call_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
                         if let Some(&(mi, ti)) = tool_index.get(call_id) {
                             let out_text = match payload.get("output") {
                                 Some(Value::String(s)) => s.clone(),
@@ -301,10 +363,13 @@ fn parse_rollout(path: &Path) -> Result<CodexParse> {
                                     .get("content")
                                     .and_then(|v| v.as_str())
                                     .map(String::from)
-                                    .unwrap_or_else(|| serde_json::to_string(o).unwrap_or_default()),
+                                    .unwrap_or_else(|| {
+                                        serde_json::to_string(o).unwrap_or_default()
+                                    }),
                                 _ => String::new(),
                             };
-                            messages[mi].tool_calls[ti].output = Some(clip(&out_text, MAX_TOOL_IO).0);
+                            messages[mi].tool_calls[ti].output =
+                                Some(clip(&out_text, MAX_TOOL_IO).0);
                         }
                     }
                     _ => {}
@@ -333,8 +398,12 @@ fn parse_rollout(path: &Path) -> Result<CodexParse> {
                     "agent_message" => {
                         if let Some(m) = payload.get("message").and_then(|v| v.as_str()) {
                             if !m.trim().is_empty() {
-                                event_fallback
-                                    .push(mk_msg(Role::Assistant, MessageKind::Text, m.trim(), ts));
+                                event_fallback.push(mk_msg(
+                                    Role::Assistant,
+                                    MessageKind::Text,
+                                    m.trim(),
+                                    ts,
+                                ));
                             }
                         }
                     }
@@ -342,7 +411,12 @@ fn parse_rollout(path: &Path) -> Result<CodexParse> {
                 }
             }
             "compacted" => {
-                messages.push(mk_msg(Role::System, MessageKind::CompactSummary, "── Context compacted ──", ts));
+                messages.push(mk_msg(
+                    Role::System,
+                    MessageKind::CompactSummary,
+                    "── Context compacted ──",
+                    ts,
+                ));
             }
             "world_state" => {}
             _ => unknown_lines += 1,
@@ -350,7 +424,9 @@ fn parse_rollout(path: &Path) -> Result<CodexParse> {
     }
 
     // response_item 完全缺席的会话退回 event_msg 流
-    let has_real = messages.iter().any(|m| m.kind == MessageKind::Text && !m.text.is_empty());
+    let has_real = messages
+        .iter()
+        .any(|m| m.kind == MessageKind::Text && !m.text.is_empty());
     let mut final_messages = if has_real {
         messages
     } else if !event_fallback.is_empty() {
@@ -410,8 +486,16 @@ fn build_meta(r: &SessionFileRef, p: &CodexParse, archived_dir: &Path) -> Sessio
         project_path: p.cwd.clone(),
         project_name,
         file_path: r.file_path.clone(),
-        created_at: if p.created_at > 0 { p.created_at } else { r.mtime_ms },
-        updated_at: if p.updated_at > 0 { p.updated_at } else { r.mtime_ms },
+        created_at: if p.created_at > 0 {
+            p.created_at
+        } else {
+            r.mtime_ms
+        },
+        updated_at: if p.updated_at > 0 {
+            p.updated_at
+        } else {
+            r.mtime_ms
+        },
         message_count: p
             .messages
             .iter()
@@ -420,8 +504,14 @@ fn build_meta(r: &SessionFileRef, p: &CodexParse, archived_dir: &Path) -> Sessio
         size_bytes: r.size,
         git_branch: p.git_branch.clone(),
         model: p.model.clone(),
-        tokens_used: if p.tokens_used > 0 { Some(p.tokens_used) } else { None },
-        archived: r.file_path.starts_with(&archived_dir.to_string_lossy().to_string()),
+        tokens_used: if p.tokens_used > 0 {
+            Some(p.tokens_used)
+        } else {
+            None
+        },
+        archived: r
+            .file_path
+            .starts_with(&archived_dir.to_string_lossy().to_string()),
         source: p.source.clone(),
         favorite: false,
         pinned: false,
@@ -439,7 +529,11 @@ impl AgentAdapter for CodexAdapter {
 
     fn list_session_files(&self) -> Result<Vec<SessionFileRef>> {
         let mut refs = list_jsonl_refs(&self.sessions_dir, AgentId::Codex, rollout_native_id);
-        refs.extend(list_jsonl_refs(&self.archived_dir, AgentId::Codex, rollout_native_id));
+        refs.extend(list_jsonl_refs(
+            &self.archived_dir,
+            AgentId::Codex,
+            rollout_native_id,
+        ));
         Ok(refs)
     }
 
@@ -452,11 +546,14 @@ impl AgentAdapter for CodexAdapter {
             let Some(row) = by_path.get(r.file_path.as_str()) else {
                 continue;
             };
-            let title = row
-                .name
-                .as_deref()
-                .filter(|n| !n.trim().is_empty())
-                .map(String::from)
+            let title = self
+                .thread_name(&row.id)
+                .or_else(|| {
+                    row.name
+                        .as_deref()
+                        .filter(|n| !n.trim().is_empty())
+                        .map(String::from)
+                })
                 .or_else(|| {
                     // Codex 自家 state DB 会把注入文本存进 title,同样要过滤
                     if is_injected_user_content(&row.title) {
@@ -505,8 +602,8 @@ impl AgentAdapter for CodexAdapter {
     }
 
     fn merge_quick_meta(&self, mut parsed: SessionMeta, quick: &SessionMeta) -> SessionMeta {
-        // state DB 的 title/name 是用户在 Codex 里手动命名,优先于首条消息推导;
-        // UNTITLED 守卫防止占位符覆盖真实标题。key/id 以 state 的线程 id 为准。
+        // session_index.thread_name / state.name / state.title 都经 quick 进来,
+        // 优先于首条消息推导。UNTITLED 守卫防止占位符覆盖真实标题。
         if !quick.title.is_empty() && quick.title != UNTITLED {
             parsed.title = quick.title.clone();
         }
@@ -527,7 +624,10 @@ impl AgentAdapter for CodexAdapter {
 
     fn parse_session(&self, r: &SessionFileRef) -> Result<ParsedSession> {
         let parsed = parse_rollout(Path::new(&r.file_path))?;
-        let meta = build_meta(r, &parsed, &self.archived_dir);
+        let mut meta = build_meta(r, &parsed, &self.archived_dir);
+        if let Some(n) = self.thread_name(&r.native_id) {
+            meta.title = n;
+        }
         let units = units_from_messages(&parsed.messages);
         Ok(ParsedSession {
             meta,
@@ -538,8 +638,12 @@ impl AgentAdapter for CodexAdapter {
 
     fn parse_transcript(&self, r: &SessionFileRef) -> Result<ParsedTranscript> {
         let parsed = parse_rollout(Path::new(&r.file_path))?;
+        let mut meta = build_meta(r, &parsed, &self.archived_dir);
+        if let Some(n) = self.thread_name(&r.native_id) {
+            meta.title = n;
+        }
         Ok(ParsedTranscript {
-            meta: build_meta(r, &parsed, &self.archived_dir),
+            meta,
             mainline: parsed.messages,
             sidechains: Vec::new(),
             unknown_line_count: parsed.unknown_lines,

--- a/crates/wake-core/src/adapters/cursor.rs
+++ b/crates/wake-core/src/adapters/cursor.rs
@@ -1,29 +1,91 @@
 use super::parse_utils::*;
+use super::sqlite_ro::open_sqlite_ro;
 use super::{units_from_messages, AgentAdapter};
 use crate::models::*;
 use anyhow::Result;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 /// Cursor CLI:`~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl` 明文。
 /// 行结构 {role, message:{content:[{type:text|tool_use}]}} + {type:"turn_ended"}。
 /// user 正文包在 <timestamp>/<user_query> 壳里;transcript 不含 cwd,
-/// 从有损 slug 目录名 DFS 反推真实路径。IDE chats(store.db 加密)不做。
+/// 从有损 slug 目录名 DFS 反推真实路径。IDE chats 正文在 store.db 加密,
+/// 但改过的标题在 Application Support 的 conversation-search.db 明文。
 pub struct CursorAdapter {
     root: PathBuf,
+    titles_db: PathBuf,
+    titles: Mutex<Option<(i64, HashMap<String, String>)>>,
 }
 
 impl CursorAdapter {
     pub fn new() -> Self {
+        let home = dirs::home_dir().unwrap_or_default();
         Self {
-            root: dirs::home_dir()
-                .unwrap_or_default()
-                .join(".cursor")
-                .join("projects"),
+            root: home.join(".cursor").join("projects"),
+            titles_db: dirs::data_dir()
+                .unwrap_or_else(|| home.join("Library").join("Application Support"))
+                .join("Cursor")
+                .join("User")
+                .join("globalStorage")
+                .join("conversation-search.db"),
+            titles: Mutex::new(None),
         }
     }
+
+    fn renamed_title(&self, id: &str) -> Option<String> {
+        self.renamed_titles().get(id).cloned()
+    }
+
+    fn renamed_titles(&self) -> HashMap<String, String> {
+        let mtime = fs::metadata(&self.titles_db)
+            .map(|m| mtime_ms(&m))
+            .unwrap_or(0);
+        {
+            let cache = self.titles.lock().unwrap();
+            if let Some((t, map)) = cache.as_ref() {
+                if *t == mtime {
+                    return map.clone();
+                }
+            }
+        }
+        let map = read_conversation_titles(&self.titles_db);
+        *self.titles.lock().unwrap() = Some((mtime, map.clone()));
+        map
+    }
+
+    fn with_renamed_title(&self, mut meta: SessionMeta) -> SessionMeta {
+        if let Some(t) = self.renamed_title(&meta.id) {
+            meta.title = t;
+        }
+        meta
+    }
+}
+
+/// Cursor IDE `/rename` 写在 conversation-search.db 的 conversations.title
+fn read_conversation_titles(db: &Path) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Some(ro) = open_sqlite_ro(db, "cursor-titles") else {
+        return map;
+    };
+    let Ok(mut stmt) = ro.conn.prepare(
+        "SELECT id, title FROM conversations WHERE title IS NOT NULL AND trim(title) != ''",
+    ) else {
+        return map;
+    };
+    let Ok(rows) = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+    else {
+        return map;
+    };
+    for row in rows.flatten() {
+        if !row.0.is_empty() && !row.1.trim().is_empty() {
+            map.insert(row.0, row.1.trim().to_string());
+        }
+    }
+    map
 }
 
 /// "Users-corey-Github-image-translate" → "/Users/corey/Github/image-translate"。
@@ -383,7 +445,7 @@ impl AgentAdapter for CursorAdapter {
 
     fn parse_session(&self, r: &SessionFileRef) -> Result<ParsedSession> {
         let parsed = parse_cursor_jsonl(Path::new(&r.file_path))?;
-        let meta = build_meta(r, &parsed);
+        let meta = self.with_renamed_title(build_meta(r, &parsed));
         let units = units_from_messages(&parsed.messages);
         Ok(ParsedSession {
             meta,
@@ -412,7 +474,7 @@ impl AgentAdapter for CursorAdapter {
             }
         }
         Ok(ParsedTranscript {
-            meta: build_meta(r, &parsed),
+            meta: self.with_renamed_title(build_meta(r, &parsed)),
             mainline: parsed.messages,
             sidechains,
             unknown_line_count: parsed.unknown_lines,
@@ -432,11 +494,16 @@ impl AgentAdapter for CursorAdapter {
     }
 
     fn watch_paths(&self) -> Vec<PathBuf> {
+        let mut v = Vec::new();
         if self.detect() {
-            vec![self.root.clone()]
-        } else {
-            Vec::new()
+            v.push(self.root.clone());
         }
+        if let Some(dir) = self.titles_db.parent() {
+            if dir.is_dir() {
+                v.push(dir.to_path_buf());
+            }
+        }
+        v
     }
 }
 

--- a/crates/wake-core/src/adapters/cursor.rs
+++ b/crates/wake-core/src/adapters/cursor.rs
@@ -27,32 +27,67 @@ impl CursorAdapter {
 }
 
 /// "Users-corey-Github-image-translate" → "/Users/corey/Github/image-translate"。
-/// '-' 既可能是路径分隔也可能是目录名字符,按磁盘真实存在的目录 DFS(优先短段);
-/// 项目目录已删时回退直译。
+/// Cursor 把路径里的 `/` 和 `_` 都压成 `-`,所以 slug 的 `-` 可能是路径分隔、
+/// 连字符目录名、或下划线。按磁盘真实存在的目录 DFS(优先短段);
+/// 短段走不通再拼更长名字,项目目录已删时回退直译(`/`)。
 fn decode_slug(slug: &str) -> String {
+    decode_slug_at(Path::new("/"), slug)
+}
+
+fn decode_slug_at(root: &Path, slug: &str) -> String {
     let parts: Vec<&str> = slug.split('-').collect();
     fn dfs(base: PathBuf, parts: &[&str]) -> Option<PathBuf> {
         if parts.is_empty() {
             return Some(base);
         }
-        let mut seg = String::new();
-        for i in 0..parts.len() {
-            if i > 0 {
-                seg.push('-');
-            }
-            seg.push_str(parts[i]);
-            let cand = base.join(&seg);
-            if cand.is_dir() {
-                if let Some(hit) = dfs(cand, &parts[i + 1..]) {
-                    return Some(hit);
+        for n in 1..=parts.len() {
+            for name in dir_name_candidates(&parts[..n]) {
+                let cand = base.join(&name);
+                if cand.is_dir() {
+                    if let Some(hit) = dfs(cand, &parts[n..]) {
+                        return Some(hit);
+                    }
                 }
             }
         }
         None
     }
-    dfs(PathBuf::from("/"), &parts)
+    dfs(root.to_path_buf(), &parts)
         .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|| format!("/{}", slug.replace('-', "/")))
+        .unwrap_or_else(|| {
+            let rest = slug.replace('-', "/");
+            if root == Path::new("/") {
+                format!("/{rest}")
+            } else {
+                root.join(rest.trim_start_matches('/'))
+                    .to_string_lossy()
+                    .into_owned()
+            }
+        })
+}
+
+/// 一段目录名:单段原样;多段把 `-`/`_` 的组合都试一遍(mask=0 为全连字符,保持旧行为优先)。
+fn dir_name_candidates(parts: &[&str]) -> Vec<String> {
+    if parts.is_empty() {
+        return Vec::new();
+    }
+    if parts.len() == 1 {
+        return vec![parts[0].to_string()];
+    }
+    let slots = parts.len() - 1;
+    if slots > 8 {
+        return vec![parts.join("-"), parts.join("_")];
+    }
+    let mut out = Vec::with_capacity(1 << slots);
+    for mask in 0..(1u32 << slots) {
+        let mut s = String::from(parts[0]);
+        for i in 0..slots {
+            s.push(if mask & (1 << i) == 0 { '-' } else { '_' });
+            s.push_str(parts[i + 1]);
+        }
+        out.push(s);
+    }
+    out
 }
 
 /// "Thursday, Jul 23, 2026, 4:00 PM (UTC+8)" → epoch ms,解析失败 = 0
@@ -60,7 +95,8 @@ fn cursor_ts_ms(s: &str) -> i64 {
     (|| -> Option<i64> {
         let (dt_part, tz_part) = s.rsplit_once(" (")?;
         let naive =
-            chrono::NaiveDateTime::parse_from_str(dt_part.trim(), "%A, %b %d, %Y, %I:%M %p").ok()?;
+            chrono::NaiveDateTime::parse_from_str(dt_part.trim(), "%A, %b %d, %Y, %I:%M %p")
+                .ok()?;
         let off = tz_part.trim_end_matches(')').strip_prefix("UTC")?;
         let (sign, rest) = match off.as_bytes().first()? {
             b'+' => (1i32, &off[1..]),
@@ -73,7 +109,12 @@ fn cursor_ts_ms(s: &str) -> i64 {
         };
         let offset = chrono::FixedOffset::east_opt(sign * secs)?;
         use chrono::TimeZone;
-        Some(offset.from_local_datetime(&naive).single()?.timestamp_millis())
+        Some(
+            offset
+                .from_local_datetime(&naive)
+                .single()?
+                .timestamp_millis(),
+        )
     })()
     .unwrap_or(0)
 }
@@ -203,7 +244,13 @@ fn parse_cursor_jsonl(path: &Path) -> Result<CursorParse> {
                             let input = b.get("input").cloned().unwrap_or(Value::Null);
                             let name = b.get("name").and_then(|v| v.as_str()).unwrap_or("tool");
                             // transcript 不落盘工具结果,output 恒 None
-                            p.tool_calls.push(tool_call_view(String::new(), name, &input, None, false));
+                            p.tool_calls.push(tool_call_view(
+                                String::new(),
+                                name,
+                                &input,
+                                None,
+                                false,
+                            ));
                         }
                         _ => {}
                     }
@@ -246,8 +293,16 @@ fn build_meta(r: &SessionFileRef, p: &CursorParse) -> SessionMeta {
         project_path: cwd.clone(),
         project_name: project_name_of(&cwd),
         file_path: r.file_path.clone(),
-        created_at: if p.created_at > 0 { p.created_at } else { r.mtime_ms },
-        updated_at: if p.updated_at > 0 { p.updated_at } else { r.mtime_ms },
+        created_at: if p.created_at > 0 {
+            p.created_at
+        } else {
+            r.mtime_ms
+        },
+        updated_at: if p.updated_at > 0 {
+            p.updated_at
+        } else {
+            r.mtime_ms
+        },
         message_count: p
             .messages
             .iter()
@@ -364,7 +419,11 @@ impl AgentAdapter for CursorAdapter {
         })
     }
 
-    fn load_sidechain(&self, r: &SessionFileRef, sidechain_id: &str) -> Result<Vec<TranscriptMessage>> {
+    fn load_sidechain(
+        &self,
+        r: &SessionFileRef,
+        sidechain_id: &str,
+    ) -> Result<Vec<TranscriptMessage>> {
         let file = subagents_dir(r).join(format!("{sidechain_id}.jsonl"));
         if !file.is_file() {
             return Ok(Vec::new());
@@ -378,5 +437,44 @@ impl AgentAdapter for CursorAdapter {
         } else {
             Vec::new()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_slug_restores_underscores() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("Works").join("app_av4");
+        fs::create_dir_all(&proj).unwrap();
+        let got = decode_slug_at(tmp.path(), "Works-app-av4");
+        assert_eq!(Path::new(&got), proj.as_path());
+    }
+
+    #[test]
+    fn decode_slug_hyphenated_dir_still_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("Github").join("image-translate");
+        fs::create_dir_all(&proj).unwrap();
+        let got = decode_slug_at(tmp.path(), "Github-image-translate");
+        assert_eq!(Path::new(&got), proj.as_path());
+    }
+
+    #[test]
+    fn decode_slug_missing_falls_back_to_slashes() {
+        let got = decode_slug("wakefx-cursor-proj");
+        assert_eq!(got, "/wakefx/cursor/proj");
+    }
+
+    #[test]
+    fn decode_slug_backtracks_when_short_prefix_is_dead_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("Works").join("app")).unwrap();
+        let proj = tmp.path().join("Works").join("app_av4");
+        fs::create_dir_all(&proj).unwrap();
+        let got = decode_slug_at(tmp.path(), "Works-app-av4");
+        assert_eq!(Path::new(&got), proj.as_path());
     }
 }

--- a/crates/wake-core/src/adapters/grok.rs
+++ b/crates/wake-core/src/adapters/grok.rs
@@ -1,3 +1,4 @@
+use super::grok_group::{self, GroupCtx};
 use super::parse_utils::*;
 use super::{units_from_messages, AgentAdapter};
 use crate::models::*;
@@ -7,6 +8,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 /// Grok Build(xAI 的 coding CLI):`~/.grok/sessions/<url编码cwd>/<uuid>/` 一目录
 /// 一会话。主文件 `updates.jsonl` 是 ACP 风格完整流水({timestamp(unix秒),
@@ -16,13 +18,27 @@ use std::path::{Path, PathBuf};
 /// Grok 自己的索引,`prompt_history.jsonl` 在 cwd 目录级——都不是会话文件。
 pub struct GrokAdapter {
     root: PathBuf,
+    grok_home: PathBuf,
+    /// 扫描生命周期内的归组快照;begin_scan 强制重载
+    group: Mutex<Option<Arc<GroupCtx>>>,
 }
 
 impl GrokAdapter {
     pub fn new() -> Self {
+        let grok_home = dirs::home_dir().unwrap_or_default().join(".grok");
         Self {
-            root: dirs::home_dir().unwrap_or_default().join(".grok").join("sessions"),
+            root: grok_home.join("sessions"),
+            grok_home,
+            group: Mutex::new(None),
         }
+    }
+
+    fn group_ctx(&self) -> Arc<GroupCtx> {
+        let mut slot = self.group.lock().unwrap();
+        if slot.is_none() {
+            *slot = Some(grok_group::load_group_ctx(&self.root, &self.grok_home));
+        }
+        Arc::clone(slot.as_ref().unwrap())
     }
 }
 
@@ -34,6 +50,7 @@ struct Summary {
     updated_ms: i64,
     git_branch: Option<String>,
     model: Option<String>,
+    git_remotes: Vec<String>,
 }
 
 fn read_summary(updates_path: &Path) -> Summary {
@@ -44,11 +61,16 @@ fn read_summary(updates_path: &Path) -> Summary {
         updated_ms: 0,
         git_branch: None,
         model: None,
+        git_remotes: Vec::new(),
     };
     let path = updates_path.with_file_name("summary.json");
     if let Ok(raw) = fs::read_to_string(&path) {
         if let Ok(v) = serde_json::from_str::<Value>(&raw) {
-            if let Some(c) = v.get("info").and_then(|i| i.get("cwd")).and_then(|x| x.as_str()) {
+            if let Some(c) = v
+                .get("info")
+                .and_then(|i| i.get("cwd"))
+                .and_then(|x| x.as_str())
+            {
                 s.cwd = c.to_string();
             }
             // generated_title 与 session_summary 通常同值,前者更语义化
@@ -76,6 +98,14 @@ fn read_summary(updates_path: &Path) -> Summary {
                 .and_then(|x| x.as_str())
                 .filter(|m| !m.is_empty())
                 .map(String::from);
+            if let Some(arr) = v.get("git_remotes").and_then(|x| x.as_array()) {
+                s.git_remotes = arr
+                    .iter()
+                    .filter_map(|x| x.as_str())
+                    .filter(|r| !r.is_empty())
+                    .map(String::from)
+                    .collect();
+            }
         }
     }
     s
@@ -108,7 +138,9 @@ impl Replay {
     }
 
     fn flush(&mut self) {
-        let Some(role) = self.cur_role.take() else { return };
+        let Some(role) = self.cur_role.take() else {
+            return;
+        };
         let text = std::mem::take(&mut self.cur_text);
         let thinking = std::mem::take(&mut self.cur_thinking);
         let tools = std::mem::take(&mut self.cur_tools);
@@ -139,14 +171,20 @@ impl Replay {
 
 /// user/agent chunk 的 content 文本({content:{type:text,text}}),借用零分配
 fn chunk_text(update: &Value) -> &str {
-    update.pointer("/content/text").and_then(Value::as_str).unwrap_or_default()
+    update
+        .pointer("/content/text")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
 }
 
 fn tool_content_text(content: &Value) -> String {
     let mut parts: Vec<String> = Vec::new();
     for item in content.as_array().into_iter().flatten() {
         let inner = item.get("content").unwrap_or(item);
-        let t = inner.get("text").and_then(|x| x.as_str()).unwrap_or_default();
+        let t = inner
+            .get("text")
+            .and_then(|x| x.as_str())
+            .unwrap_or_default();
         if !t.trim().is_empty() {
             parts.push(t.trim().to_string());
         }
@@ -214,10 +252,17 @@ fn parse_grok_updates(path: &Path) -> Result<(Vec<TranscriptMessage>, u32)> {
             }
             Some("tool_call") => {
                 rp.ensure(Role::Assistant, ts);
-                let id = update.get("toolCallId").and_then(|v| v.as_str()).unwrap_or_default();
-                let name = update.get("title").and_then(|v| v.as_str()).unwrap_or_default();
+                let id = update
+                    .get("toolCallId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let name = update
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
                 let input = update.get("rawInput").cloned().unwrap_or(Value::Null);
-                rp.cur_tools.push(tool_call_view(id.to_string(), name, &input, None, false));
+                rp.cur_tools
+                    .push(tool_call_view(id.to_string(), name, &input, None, false));
             }
             Some("tool_call_update") => {
                 let Some(id) = update.get("toolCallId").and_then(|v| v.as_str()) else {
@@ -251,26 +296,45 @@ fn parse_grok_updates(path: &Path) -> Result<(Vec<TranscriptMessage>, u32)> {
     Ok((messages, unknown))
 }
 
-fn build_meta(r: &SessionFileRef, side: &Summary, messages: &[TranscriptMessage]) -> SessionMeta {
+fn build_meta(
+    r: &SessionFileRef,
+    side: &Summary,
+    messages: &[TranscriptMessage],
+    grok_home: &Path,
+    ctx: &GroupCtx,
+) -> SessionMeta {
     let title = Some(clean_title_candidate(&side.title))
         .filter(|t| !t.is_empty())
         .or_else(|| title_from_messages(messages))
         .unwrap_or_else(|| UNTITLED.to_string());
-    let msg_ts_max = messages.iter().filter_map(|m| m.timestamp).max().unwrap_or(0);
+    let msg_ts_max = messages
+        .iter()
+        .filter_map(|m| m.timestamp)
+        .max()
+        .unwrap_or(0);
+    let (project_path, project_name) =
+        grok_group::canonical_project(&side.cwd, &side.git_remotes, grok_home, &r.native_id, ctx);
     SessionMeta {
         key: format!("grok:{}", r.native_id),
         id: r.native_id.clone(),
         agent: AgentId::Grok,
         title,
-        project_path: side.cwd.clone(),
-        project_name: project_name_of(&side.cwd),
+        project_path,
+        project_name,
         file_path: r.file_path.clone(),
-        created_at: if side.created_ms > 0 { side.created_ms } else { r.mtime_ms },
+        created_at: if side.created_ms > 0 {
+            side.created_ms
+        } else {
+            r.mtime_ms
+        },
         updated_at: match side.updated_ms.max(msg_ts_max) {
             t if t > 0 => t,
             _ => r.mtime_ms,
         },
-        message_count: messages.iter().filter(|m| m.kind == MessageKind::Text).count() as i64,
+        message_count: messages
+            .iter()
+            .filter(|m| m.kind == MessageKind::Text)
+            .count() as i64,
         size_bytes: r.size,
         git_branch: side.git_branch.clone(),
         model: side.model.clone(),
@@ -291,6 +355,14 @@ impl AgentAdapter for GrokAdapter {
         self.root.is_dir()
     }
 
+    fn begin_scan(&self) {
+        *self.group.lock().unwrap() = Some(grok_group::load_group_ctx(&self.root, &self.grok_home));
+    }
+
+    fn parent_links(&self) -> Vec<(String, String)> {
+        grok_group::parent_links(&self.group_ctx())
+    }
+
     fn list_session_files(&self) -> Result<Vec<SessionFileRef>> {
         let mut refs = Vec::new();
         let Ok(cwds) = fs::read_dir(&self.root) else {
@@ -299,7 +371,9 @@ impl AgentAdapter for GrokAdapter {
         // session_search.sqlite 等根级文件对 read_dir 自然失败跳过;
         // 会话主文件的判定(存在、非空、native_id)统一走 file_ref
         for cwd_dir in cwds.flatten() {
-            let Ok(sessions) = fs::read_dir(cwd_dir.path()) else { continue };
+            let Ok(sessions) = fs::read_dir(cwd_dir.path()) else {
+                continue;
+            };
             for sess in sessions.flatten() {
                 if let Some(r) = self.file_ref(&sess.path().join("updates.jsonl")) {
                     refs.push(r);
@@ -331,7 +405,7 @@ impl AgentAdapter for GrokAdapter {
     fn parse_session(&self, r: &SessionFileRef) -> Result<ParsedSession> {
         let (messages, unknown) = parse_grok_updates(Path::new(&r.file_path))?;
         let side = read_summary(Path::new(&r.file_path));
-        let meta = build_meta(r, &side, &messages);
+        let meta = build_meta(r, &side, &messages, &self.grok_home, &self.group_ctx());
         let units = units_from_messages(&messages);
         Ok(ParsedSession {
             meta,
@@ -344,7 +418,7 @@ impl AgentAdapter for GrokAdapter {
         let (messages, unknown) = parse_grok_updates(Path::new(&r.file_path))?;
         let side = read_summary(Path::new(&r.file_path));
         Ok(ParsedTranscript {
-            meta: build_meta(r, &side, &messages),
+            meta: build_meta(r, &side, &messages, &self.grok_home, &self.group_ctx()),
             mainline: messages,
             sidechains: Vec::new(),
             unknown_line_count: unknown,

--- a/crates/wake-core/src/adapters/grok.rs
+++ b/crates/wake-core/src/adapters/grok.rs
@@ -73,7 +73,7 @@ fn read_summary(updates_path: &Path) -> Summary {
             {
                 s.cwd = c.to_string();
             }
-            // generated_title 与 session_summary 通常同值,前者更语义化
+            // /rename 写 generated_title 并钉 title_is_manual;session_summary 是自动摘要
             for k in ["generated_title", "session_summary"] {
                 if let Some(t) = v.get(k).and_then(|x| x.as_str()) {
                     if !t.trim().is_empty() {

--- a/crates/wake-core/src/adapters/grok_group.rs
+++ b/crates/wake-core/src/adapters/grok_group.rs
@@ -1,0 +1,528 @@
+//! Grok 会话归组:主会话 subagents 反查优先,无父时 worktree/remote 启发式兜底。
+use super::parse_utils::project_name_of;
+use super::sqlite_ro::open_sqlite_ro;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+/// 一轮扫描共享的归组快照
+#[derive(Clone, Debug, Default)]
+pub struct GroupCtx {
+    pub worktrees: Vec<WorktreeRow>,
+    pub parents: HashMap<String, ParentRef>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WorktreeRow {
+    pub path: String,
+    pub source_repo: String,
+    pub repo_name: String,
+}
+
+/// 主会话登记的子代理:child_id → 父会话 id 与父 cwd
+#[derive(Clone, Debug)]
+pub struct ParentRef {
+    pub parent_id: String,
+    pub parent_cwd: String,
+}
+
+pub fn load_group_ctx(sessions_root: &Path, grok_home: &Path) -> Arc<GroupCtx> {
+    Arc::new(GroupCtx {
+        worktrees: load_worktree_rows(grok_home),
+        parents: load_subagent_parents(sessions_root),
+    })
+}
+
+/// (child_key, parent_key) 全量父子链,给 store 旁写
+pub fn parent_links(ctx: &GroupCtx) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for child_id in ctx.parents.keys() {
+        if !seen.insert(child_id.clone()) {
+            continue;
+        }
+        if let Some(p) = root_parent(child_id, &ctx.parents) {
+            out.push((format!("grok:{child_id}"), format!("grok:{}", p.parent_id)));
+        }
+    }
+    out
+}
+
+pub fn canonical_project(
+    cwd: &str,
+    remotes: &[String],
+    grok_home: &Path,
+    child_id: &str,
+    ctx: &GroupCtx,
+) -> (String, String) {
+    if let Some(pair) = parent_project(child_id, &ctx.parents) {
+        return pair;
+    }
+    if cwd.is_empty() {
+        return (String::new(), project_name_of(cwd));
+    }
+    let slug = grok_worktree_slug(cwd, grok_home);
+    if let Some(pair) = lookup_source(cwd, slug.as_deref(), &ctx.worktrees) {
+        return pair;
+    }
+    if let Some(slug) = slug {
+        let path = grok_home
+            .join("worktrees")
+            .join(&slug)
+            .to_string_lossy()
+            .into_owned();
+        let name = remotes
+            .iter()
+            .find_map(|r| repo_name_from_remote(r))
+            .unwrap_or_else(|| slug.strip_prefix("github-").unwrap_or(&slug).to_string());
+        return (path, name);
+    }
+    if is_ephemeral_worktree(cwd) {
+        if let Some(remote) = remotes.iter().find(|r| !r.is_empty()) {
+            if let Some(local) = local_checkout_from_remote(remote) {
+                return (local.clone(), project_name_of(&local));
+            }
+            if let Some(name) = repo_name_from_remote(remote) {
+                return (format!("git-remote:{name}"), name);
+            }
+        }
+        if let Some(path) = ephemeral_plan_path(cwd) {
+            return (path.clone(), project_name_of(&path));
+        }
+    }
+    (cwd.to_string(), project_name_of(cwd))
+}
+
+fn normalize_path(s: &str) -> String {
+    let s = s.trim_end_matches('/');
+    if let Some(rest) = s.strip_prefix("/private/") {
+        if rest.starts_with("var/") {
+            return format!("/{rest}");
+        }
+    }
+    s.to_string()
+}
+
+fn load_worktree_rows(grok_home: &Path) -> Vec<WorktreeRow> {
+    let db = grok_home.join("worktrees.db");
+    let Some(ro) = open_sqlite_ro(&db, "grok-worktrees") else {
+        return Vec::new();
+    };
+    let mut stmt = match ro.conn.prepare(
+        "SELECT path, source_repo, repo_name FROM worktrees WHERE path != '' AND source_repo != ''",
+    ) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let rows = stmt.query_map([], |r| {
+        Ok(WorktreeRow {
+            path: r.get(0)?,
+            source_repo: r.get(1)?,
+            repo_name: r.get::<_, String>(2).unwrap_or_default(),
+        })
+    });
+    let Ok(rows) = rows else {
+        return Vec::new();
+    };
+    rows.flatten().collect()
+}
+
+fn hex_digit(c: u8) -> Option<u8> {
+    Some(match c {
+        b'0'..=b'9' => c - b'0',
+        b'a'..=b'f' => c - b'a' + 10,
+        b'A'..=b'F' => c - b'A' + 10,
+        _ => return None,
+    })
+}
+
+fn percent_decode(input: &str) -> String {
+    let b = input.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'%' && i + 2 < b.len() {
+            if let (Some(h), Some(l)) = (hex_digit(b[i + 1]), hex_digit(b[i + 2])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(b[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn group_cwd(cwd_dir: &Path) -> String {
+    let marker = cwd_dir.join(".cwd");
+    if let Ok(s) = fs::read_to_string(marker) {
+        let t = s.trim();
+        if !t.is_empty() {
+            return t.to_string();
+        }
+    }
+    percent_decode(&cwd_dir.file_name().unwrap_or_default().to_string_lossy())
+}
+
+fn load_subagent_parents(sessions_root: &Path) -> HashMap<String, ParentRef> {
+    let mut map = HashMap::new();
+    let Ok(groups) = fs::read_dir(sessions_root) else {
+        return map;
+    };
+    for group in groups.flatten() {
+        let group_path = group.path();
+        if !group_path.is_dir() {
+            continue;
+        }
+        let parent_cwd = group_cwd(&group_path);
+        if parent_cwd.is_empty() {
+            continue;
+        }
+        let Ok(sessions) = fs::read_dir(&group_path) else {
+            continue;
+        };
+        for sess in sessions.flatten() {
+            let sess_path = sess.path();
+            let sub = sess_path.join("subagents");
+            if !sub.is_dir() {
+                continue;
+            }
+            let folder_id = sess_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned();
+            let Ok(kids) = fs::read_dir(&sub) else {
+                continue;
+            };
+            for kid in kids.flatten() {
+                let meta_path = kid.path().join("meta.json");
+                let Ok(raw) = fs::read_to_string(meta_path) else {
+                    continue;
+                };
+                let Ok(v) = serde_json::from_str::<Value>(&raw) else {
+                    continue;
+                };
+                let parent_id = v
+                    .get("parent_session_id")
+                    .and_then(|x| x.as_str())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(&folder_id)
+                    .to_string();
+                let info = ParentRef {
+                    parent_id,
+                    parent_cwd: parent_cwd.clone(),
+                };
+                for key in ["child_session_id", "subagent_id"] {
+                    if let Some(id) = v
+                        .get(key)
+                        .and_then(|x| x.as_str())
+                        .filter(|s| !s.is_empty())
+                    {
+                        map.entry(id.to_string()).or_insert_with(|| info.clone());
+                    }
+                }
+            }
+        }
+    }
+    map
+}
+
+fn root_parent(child_id: &str, parents: &HashMap<String, ParentRef>) -> Option<ParentRef> {
+    if child_id.is_empty() {
+        return None;
+    }
+    let mut id = child_id.to_string();
+    let mut seen = HashSet::new();
+    let mut last = None;
+    while seen.insert(id.clone()) {
+        let Some(p) = parents.get(&id) else {
+            break;
+        };
+        last = Some(p.clone());
+        if parents.contains_key(&p.parent_id) {
+            id = p.parent_id.clone();
+        } else {
+            break;
+        }
+    }
+    last.filter(|p| !p.parent_cwd.is_empty() && !p.parent_id.is_empty())
+}
+
+fn parent_project(
+    child_id: &str,
+    parents: &HashMap<String, ParentRef>,
+) -> Option<(String, String)> {
+    root_parent(child_id, parents).map(|p| (p.parent_cwd.clone(), project_name_of(&p.parent_cwd)))
+}
+
+fn grok_worktree_slug(cwd: &str, grok_home: &Path) -> Option<String> {
+    let rel = Path::new(cwd)
+        .strip_prefix(grok_home.join("worktrees"))
+        .ok()?;
+    let slug = rel.components().next()?.as_os_str().to_str()?;
+    if slug.is_empty() {
+        None
+    } else {
+        Some(slug.to_string())
+    }
+}
+
+fn is_ephemeral_worktree(cwd: &str) -> bool {
+    let name = Path::new(cwd)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    if !name.starts_with("wt-") {
+        return false;
+    }
+    cwd.contains("/T/grok-") || cwd.contains("/var/folders/") || cwd.contains("/tmp/")
+}
+
+fn local_checkout_from_remote(remote: &str) -> Option<String> {
+    if !remote.starts_with('/') {
+        return None;
+    }
+    for suffix in [".origin.git", ".git"] {
+        if let Some(stem) = remote.strip_suffix(suffix) {
+            if !stem.is_empty() {
+                return Some(stem.to_string());
+            }
+        }
+    }
+    Some(remote.trim_end_matches('/').to_string())
+}
+
+fn repo_name_from_remote(remote: &str) -> Option<String> {
+    if let Some(local) = local_checkout_from_remote(remote) {
+        return Path::new(&local)
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned());
+    }
+    let s = remote.trim().trim_end_matches('/').trim_end_matches(".git");
+    let name = s.rsplit(['/', ':']).next()?;
+    if name.is_empty() || name.contains('@') {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn lookup_source(cwd: &str, slug: Option<&str>, rows: &[WorktreeRow]) -> Option<(String, String)> {
+    let cwd_n = normalize_path(cwd);
+    for r in rows {
+        let p = normalize_path(&r.path);
+        if cwd_n == p || cwd_n.starts_with(&format!("{p}/")) {
+            let name = if r.repo_name.is_empty() {
+                project_name_of(&r.source_repo)
+            } else {
+                r.repo_name.clone()
+            };
+            return Some((r.source_repo.clone(), name));
+        }
+    }
+    let slug = slug?;
+    let needle = format!("/worktrees/{slug}");
+    for r in rows {
+        let p = normalize_path(&r.path);
+        if p.contains(&format!("{needle}/")) || p.ends_with(&needle) || r.repo_name == slug {
+            let name = if r.repo_name.is_empty() {
+                project_name_of(&r.source_repo)
+            } else {
+                r.repo_name.clone()
+            };
+            return Some((r.source_repo.clone(), name));
+        }
+    }
+    None
+}
+
+fn ephemeral_plan_path(cwd: &str) -> Option<String> {
+    let path = Path::new(cwd);
+    let name = path.file_name()?.to_str()?;
+    let plan = name
+        .rsplit_once("-pr-")
+        .map(|(head, _)| head)
+        .unwrap_or(name);
+    let parent = path.parent()?;
+    Some(parent.join(plan).to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn grok_home() -> PathBuf {
+        PathBuf::from("/Users/tester/.grok")
+    }
+
+    fn ctx_with(parents: HashMap<String, ParentRef>, worktrees: Vec<WorktreeRow>) -> GroupCtx {
+        GroupCtx { worktrees, parents }
+    }
+
+    fn resolve(cwd: &str, remotes: &[&str], worktrees: Vec<WorktreeRow>) -> (String, String) {
+        let remotes: Vec<String> = remotes.iter().map(|s| (*s).to_string()).collect();
+        canonical_project(
+            cwd,
+            &remotes,
+            &grok_home(),
+            "",
+            &ctx_with(HashMap::new(), worktrees),
+        )
+    }
+
+    #[test]
+    fn ordinary_cwd_unchanged() {
+        let (path, name) = resolve("/Users/tester/Github/wakefx", &[], Vec::new());
+        assert_eq!(path, "/Users/tester/Github/wakefx");
+        assert_eq!(name, "wakefx");
+    }
+
+    #[test]
+    fn ephemeral_worktree_follows_local_origin_remote() {
+        let (path, name) = resolve(
+            "/var/folders/xx/T/grok-501/wt-abcd1234-pr-9",
+            &["/Users/tester/Github/wakefx.origin.git"],
+            Vec::new(),
+        );
+        assert_eq!(path, "/Users/tester/Github/wakefx");
+        assert_eq!(name, "wakefx");
+    }
+
+    #[test]
+    fn ephemeral_worktree_without_remote_groups_by_plan() {
+        let (pa, na) = resolve(
+            "/var/folders/xx/T/grok-501/wt-abcd1234-pr-9",
+            &[],
+            Vec::new(),
+        );
+        let (pb, nb) = resolve(
+            "/var/folders/xx/T/grok-501/wt-abcd1234-pr-15",
+            &[],
+            Vec::new(),
+        );
+        assert_eq!(pa, pb);
+        assert_eq!(pa, "/var/folders/xx/T/grok-501/wt-abcd1234");
+        assert_eq!(na, "wt-abcd1234");
+        assert_eq!(nb, "wt-abcd1234");
+    }
+
+    #[test]
+    fn named_worktree_uses_registry_source_repo() {
+        let rows = vec![WorktreeRow {
+            path: "/Users/tester/.grok/worktrees/works-app-av4/2026-08-15-label".into(),
+            source_repo: "/Users/tester/Works/app_av4".into(),
+            repo_name: "app_av4".into(),
+        }];
+        let (path, name) = resolve(
+            "/Users/tester/.grok/worktrees/works-app-av4/subagent-abc",
+            &[],
+            rows,
+        );
+        assert_eq!(path, "/Users/tester/Works/app_av4");
+        assert_eq!(name, "app_av4");
+    }
+
+    #[test]
+    fn named_worktree_without_registry_groups_by_slug() {
+        let (path, name) = resolve(
+            "/Users/tester/.grok/worktrees/github-react-native-syan-image-picker/subagent-1",
+            &["https://github.com/syanbo/react-native-syan-image-picker.git"],
+            Vec::new(),
+        );
+        assert_eq!(
+            path,
+            "/Users/tester/.grok/worktrees/github-react-native-syan-image-picker"
+        );
+        assert_eq!(name, "react-native-syan-image-picker");
+    }
+
+    #[test]
+    fn subagent_uses_orchestrator_cwd_over_worktree_and_remote() {
+        let mut parents = HashMap::new();
+        parents.insert(
+            "child-1".into(),
+            ParentRef {
+                parent_id: "orch".into(),
+                parent_cwd: "/Users/tester/Desktop/AI/Grok".into(),
+            },
+        );
+        let remotes = ["/Users/tester/Github/wakefx.origin.git".to_string()];
+        let (path, name) = canonical_project(
+            "/var/folders/xx/T/grok-501/wt-abcd1234-pr-9",
+            &remotes,
+            &grok_home(),
+            "child-1",
+            &ctx_with(parents, Vec::new()),
+        );
+        assert_eq!(path, "/Users/tester/Desktop/AI/Grok");
+        assert_eq!(name, "Grok");
+    }
+
+    #[test]
+    fn nested_subagent_walks_to_root_parent() {
+        let mut parents = HashMap::new();
+        parents.insert(
+            "child-2".into(),
+            ParentRef {
+                parent_id: "child-1".into(),
+                parent_cwd: "/var/folders/xx/wt".into(),
+            },
+        );
+        parents.insert(
+            "child-1".into(),
+            ParentRef {
+                parent_id: "orch".into(),
+                parent_cwd: "/Users/tester/Desktop/AI/Grok".into(),
+            },
+        );
+        let (path, name) = canonical_project(
+            "/var/folders/xx/wt",
+            &[],
+            &grok_home(),
+            "child-2",
+            &ctx_with(parents, Vec::new()),
+        );
+        assert_eq!(path, "/Users/tester/Desktop/AI/Grok");
+        assert_eq!(name, "Grok");
+    }
+
+    #[test]
+    fn percent_decode_cwd_group() {
+        assert_eq!(
+            percent_decode("%2FUsers%2Ftester%2FDesktop%2FAI%2FGrok"),
+            "/Users/tester/Desktop/AI/Grok"
+        );
+    }
+
+    #[test]
+    fn load_subagent_parents_from_session_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let meta_dir = tmp
+            .path()
+            .join("%2FUsers%2Ftester%2FDesktop%2FAI%2FGrok")
+            .join("orch-id")
+            .join("subagents")
+            .join("child-id");
+        fs::create_dir_all(&meta_dir).unwrap();
+        fs::write(
+            meta_dir.join("meta.json"),
+            r#"{"parent_session_id":"orch-id","child_session_id":"child-id","subagent_id":"child-id"}"#,
+        )
+        .unwrap();
+        let map = load_subagent_parents(tmp.path());
+        let p = map.get("child-id").expect("child mapped");
+        assert_eq!(p.parent_id, "orch-id");
+        assert_eq!(p.parent_cwd, "/Users/tester/Desktop/AI/Grok");
+        let ctx = GroupCtx {
+            worktrees: Vec::new(),
+            parents: map,
+        };
+        let links = parent_links(&ctx);
+        assert!(links.contains(&("grok:child-id".into(), "grok:orch-id".into())));
+    }
+}

--- a/crates/wake-core/src/adapters/mod.rs
+++ b/crates/wake-core/src/adapters/mod.rs
@@ -10,6 +10,7 @@ pub mod kiro;
 pub mod opencode;
 pub mod pi;
 
+mod grok_group;
 pub(crate) mod parse_utils;
 mod sqlite_ro;
 
@@ -32,7 +33,10 @@ pub trait AgentAdapter: Send + Sync {
         parse_utils::default_file_ref(self.agent(), path)
     }
     /// 快路径:不解析文件直接给出 meta(Codex 走 state DB)。None = 无快路径
-    fn quick_meta(&self, _refs: &[SessionFileRef]) -> Option<std::collections::HashMap<String, SessionMeta>> {
+    fn quick_meta(
+        &self,
+        _refs: &[SessionFileRef],
+    ) -> Option<std::collections::HashMap<String, SessionMeta>> {
         None
     }
     /// quick 与 parsed 的合并策略:默认 parsed 为准、quick 补缺。
@@ -54,7 +58,11 @@ pub trait AgentAdapter: Send + Sync {
     /// 详情解析
     fn parse_transcript(&self, r: &SessionFileRef) -> Result<ParsedTranscript>;
     /// 加载 sidechain 消息(仅 Claude/Cursor subagents)
-    fn load_sidechain(&self, _r: &SessionFileRef, _sidechain_id: &str) -> Result<Vec<TranscriptMessage>> {
+    fn load_sidechain(
+        &self,
+        _r: &SessionFileRef,
+        _sidechain_id: &str,
+    ) -> Result<Vec<TranscriptMessage>> {
         Ok(Vec::new())
     }
     /// 会话在磁盘上的全部归属路径(删除时一并 trash)。默认仅主文件;
@@ -64,6 +72,12 @@ pub trait AgentAdapter: Send + Sync {
     }
     /// 文件监听根目录
     fn watch_paths(&self) -> Vec<std::path::PathBuf>;
+    /// 一轮扫描开始前刷新 adapter 侧缓存(默认 no-op)
+    fn begin_scan(&self) {}
+    /// (child_key, parent_key) 父子链,扫描后由 store 旁写(默认空)
+    fn parent_links(&self) -> Vec<(String, String)> {
+        Vec::new()
+    }
 }
 
 pub fn create_adapters() -> Vec<Box<dyn AgentAdapter>> {

--- a/crates/wake-core/src/adapters/pi.rs
+++ b/crates/wake-core/src/adapters/pi.rs
@@ -50,6 +50,7 @@ fn native_id_of(stem: &str) -> String {
 
 struct PiParse {
     session_id: Option<String>,
+    title: String,
     cwd: String,
     created_at: i64,
     /// 最后一行消息的时间(合并后的消息保留回合首行时间,updated 单独追踪)
@@ -66,6 +67,7 @@ fn parse_pi_jsonl(path: &Path) -> Result<PiParse> {
 
     let mut p = PiParse {
         session_id: None,
+        title: String::new(),
         cwd: String::new(),
         created_at: 0,
         last_ts: 0,
@@ -97,6 +99,15 @@ fn parse_pi_jsonl(path: &Path) -> Result<PiParse> {
                 if let Some(c) = row.get("cwd").and_then(|v| v.as_str()) {
                     p.cwd = c.to_string();
                 }
+                if let Some(t) = row
+                    .get("title")
+                    .or_else(|| row.get("name"))
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    p.title = t.to_string();
+                }
                 if let Some(t) = row.get("timestamp").and_then(|v| v.as_str()) {
                     p.created_at = iso_ms(t);
                 }
@@ -106,7 +117,11 @@ fn parse_pi_jsonl(path: &Path) -> Result<PiParse> {
                     p.unknown_lines += 1;
                     continue;
                 };
-                let ts = row.get("timestamp").and_then(|v| v.as_str()).map(iso_ms).unwrap_or(0);
+                let ts = row
+                    .get("timestamp")
+                    .and_then(|v| v.as_str())
+                    .map(iso_ms)
+                    .unwrap_or(0);
                 p.last_ts = p.last_ts.max(ts);
                 let content = msg.get("content").unwrap_or(&serde_json::Value::Null);
                 match msg.get("role").and_then(|v| v.as_str()) {
@@ -122,9 +137,19 @@ fn parse_pi_jsonl(path: &Path) -> Result<PiParse> {
                         for b in content.as_array().into_iter().flatten() {
                             if b.get("type").and_then(|v| v.as_str()) == Some("toolCall") {
                                 let id = b.get("id").and_then(|v| v.as_str()).unwrap_or_default();
-                                let name = b.get("name").and_then(|v| v.as_str()).unwrap_or_default();
-                                let input = b.get("arguments").cloned().unwrap_or(serde_json::Value::Null);
-                                tools.push(tool_call_view(id.to_string(), name, &input, None, false));
+                                let name =
+                                    b.get("name").and_then(|v| v.as_str()).unwrap_or_default();
+                                let input = b
+                                    .get("arguments")
+                                    .cloned()
+                                    .unwrap_or(serde_json::Value::Null);
+                                tools.push(tool_call_view(
+                                    id.to_string(),
+                                    name,
+                                    &input,
+                                    None,
+                                    false,
+                                ));
                             }
                         }
                         if text.is_empty() && tools.is_empty() {
@@ -202,7 +227,10 @@ fn parse_pi_jsonl(path: &Path) -> Result<PiParse> {
 
 fn build_meta(agent: AgentId, r: &SessionFileRef, p: &PiParse) -> SessionMeta {
     let native = p.session_id.clone().unwrap_or_else(|| r.native_id.clone());
-    let title = title_from_messages(&p.messages).unwrap_or_else(|| UNTITLED.to_string());
+    let title = Some(clean_title_candidate(&p.title))
+        .filter(|t| !t.is_empty())
+        .or_else(|| title_from_messages(&p.messages))
+        .unwrap_or_else(|| UNTITLED.to_string());
     SessionMeta {
         key: format!("{}:{native}", agent.as_str()),
         id: native,
@@ -211,9 +239,17 @@ fn build_meta(agent: AgentId, r: &SessionFileRef, p: &PiParse) -> SessionMeta {
         project_path: p.cwd.clone(),
         project_name: project_name_of(&p.cwd),
         file_path: r.file_path.clone(),
-        created_at: if p.created_at > 0 { p.created_at } else { r.mtime_ms },
+        created_at: if p.created_at > 0 {
+            p.created_at
+        } else {
+            r.mtime_ms
+        },
         updated_at: if p.last_ts > 0 { p.last_ts } else { r.mtime_ms },
-        message_count: p.messages.iter().filter(|m| m.kind == MessageKind::Text).count() as i64,
+        message_count: p
+            .messages
+            .iter()
+            .filter(|m| m.kind == MessageKind::Text)
+            .count() as i64,
         size_bytes: r.size,
         git_branch: None,
         model: p.model.clone(),

--- a/crates/wake-core/src/db.rs
+++ b/crates/wake-core/src/db.rs
@@ -26,7 +26,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   file_path      TEXT NOT NULL UNIQUE,
   file_size      INTEGER DEFAULT 0,
   file_mtime     INTEGER DEFAULT 0,
-  unknown_lines  INTEGER DEFAULT 0
+  unknown_lines  INTEGER DEFAULT 0,
+  parent_key     TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_updated ON sessions(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_agent   ON sessions(agent_id, updated_at DESC);
@@ -71,7 +72,32 @@ fn open_conn(path: &Path) -> Result<Connection> {
     conn.busy_timeout(std::time::Duration::from_millis(3000))?;
     conn.execute_batch(DDL)
         .context("failed to initialize SQLite schema")?;
+    migrate_sessions(&conn)?;
     Ok(conn)
+}
+
+/// 旧库 CREATE TABLE IF NOT EXISTS 不会加新列,这里补 parent_key
+fn migrate_sessions(conn: &Connection) -> Result<()> {
+    let mut has_parent = false;
+    let mut stmt = conn.prepare("PRAGMA table_info(sessions)")?;
+    let rows = stmt.query_map([], |r| r.get::<_, String>(1))?;
+    for name in rows.flatten() {
+        if name == "parent_key" {
+            has_parent = true;
+            break;
+        }
+    }
+    if !has_parent {
+        conn.execute(
+            "ALTER TABLE sessions ADD COLUMN parent_key TEXT NOT NULL DEFAULT ''",
+            [],
+        )?;
+    }
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_key)",
+        [],
+    )?;
+    Ok(())
 }
 
 /// 打开索引库;打不开就把它连同 WAL/SHM 一起挪到 `.corrupt` 旁路再建一个空的。
@@ -89,8 +115,7 @@ pub fn open_or_rebuild(path: &Path) -> Result<(Store, Option<String>)> {
     for suffix in ["-wal", "-shm"] {
         let _ = std::fs::remove_file(format!("{}{suffix}", path.display()));
     }
-    let store = Store::open(path)
-        .with_context(|| format!("rebuild failed after: {first}"))?;
+    let store = Store::open(path).with_context(|| format!("rebuild failed after: {first}"))?;
     Ok((
         store,
         Some(format!(
@@ -117,21 +142,31 @@ impl Store {
 
     // ---------- 写路径(扫描器/用户操作) ----------
 
-    pub fn write_session(&self, meta: &SessionMeta, file_mtime: i64, units: &[IndexUnit]) -> Result<()> {
+    pub fn write_session(
+        &self,
+        meta: &SessionMeta,
+        file_mtime: i64,
+        units: &[IndexUnit],
+    ) -> Result<()> {
         let mut conn = self.write.lock().unwrap();
         let tx = conn.transaction()?;
         {
             // FTS external content 需要显式 delete 旧行
-            let mut sel = tx.prepare_cached("SELECT id, text FROM messages WHERE session_key = ?1")?;
+            let mut sel =
+                tx.prepare_cached("SELECT id, text FROM messages WHERE session_key = ?1")?;
             let rows: Vec<(i64, String)> = sel
                 .query_map(params![meta.key], |r| Ok((r.get(0)?, r.get(1)?)))?
                 .collect::<rusqlite::Result<_>>()?;
-            let mut fts_del =
-                tx.prepare_cached("INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', ?1, ?2)")?;
+            let mut fts_del = tx.prepare_cached(
+                "INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', ?1, ?2)",
+            )?;
             for (id, text) in rows {
                 fts_del.execute(params![id, text])?;
             }
-            tx.execute("DELETE FROM messages WHERE session_key = ?1", params![meta.key])?;
+            tx.execute(
+                "DELETE FROM messages WHERE session_key = ?1",
+                params![meta.key],
+            )?;
 
             upsert_session(&tx, meta, file_mtime)?;
 
@@ -172,14 +207,20 @@ impl Store {
         let tx = conn.transaction()?;
         {
             let file_path: Option<String> = tx
-                .query_row("SELECT file_path FROM sessions WHERE key = ?1", params![key], |r| r.get(0))
+                .query_row(
+                    "SELECT file_path FROM sessions WHERE key = ?1",
+                    params![key],
+                    |r| r.get(0),
+                )
                 .optional()?;
-            let mut sel = tx.prepare_cached("SELECT id, text FROM messages WHERE session_key = ?1")?;
+            let mut sel =
+                tx.prepare_cached("SELECT id, text FROM messages WHERE session_key = ?1")?;
             let rows: Vec<(i64, String)> = sel
                 .query_map(params![key], |r| Ok((r.get(0)?, r.get(1)?)))?
                 .collect::<rusqlite::Result<_>>()?;
-            let mut fts_del =
-                tx.prepare_cached("INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', ?1, ?2)")?;
+            let mut fts_del = tx.prepare_cached(
+                "INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', ?1, ?2)",
+            )?;
             for (id, text) in rows {
                 fts_del.execute(params![id, text])?;
             }
@@ -214,7 +255,12 @@ impl Store {
         Ok(())
     }
 
-    pub fn set_user_data(&self, key: &str, favorite: Option<bool>, pinned: Option<bool>) -> Result<()> {
+    pub fn set_user_data(
+        &self,
+        key: &str,
+        favorite: Option<bool>,
+        pinned: Option<bool>,
+    ) -> Result<()> {
         let conn = self.write.lock().unwrap();
         conn.execute(
             "INSERT INTO user_data(session_key, favorite, pinned, updated_at)
@@ -223,7 +269,12 @@ impl Store {
                favorite = COALESCE(?2, user_data.favorite),
                pinned   = COALESCE(?3, user_data.pinned),
                updated_at = excluded.updated_at",
-            params![key, favorite.map(|v| v as i64), pinned.map(|v| v as i64), now_ms()],
+            params![
+                key,
+                favorite.map(|v| v as i64),
+                pinned.map(|v| v as i64),
+                now_ms()
+            ],
         )?;
         Ok(())
     }
@@ -240,7 +291,8 @@ impl Store {
 
     pub fn known_files(&self) -> Result<HashMap<String, (i64, i64, String)>> {
         let conn = self.read.lock().unwrap();
-        let mut stmt = conn.prepare_cached("SELECT file_path, file_mtime, file_size, key FROM sessions")?;
+        let mut stmt =
+            conn.prepare_cached("SELECT file_path, file_mtime, file_size, key FROM sessions")?;
         let rows = stmt.query_map([], |r| {
             Ok((r.get::<_, String>(0)?, (r.get(1)?, r.get(2)?, r.get(3)?)))
         })?;
@@ -291,15 +343,34 @@ impl Store {
             args.push(Box::new(like.clone()));
             args.push(Box::new(like));
         }
+        if f.roots_only {
+            if f.include_archived {
+                wheres.push(ROOT_IGNORING_ARCHIVED.into());
+            } else {
+                wheres.push(ROOT_WHEN_HIDING_ARCHIVED.into());
+            }
+        }
         let where_sql = if wheres.is_empty() {
             String::new()
         } else {
             format!("WHERE {}", wheres.join(" AND "))
         };
-        let order_col = match f.sort {
-            SortKey::Updated => "s.updated_at",
-            SortKey::Created => "s.created_at",
-            SortKey::Messages => "s.message_count",
+        let order_col = if f.roots_only {
+            match f.sort {
+                SortKey::Updated => {
+                    "MAX(s.updated_at, COALESCE((SELECT MAX(c.updated_at) FROM sessions c WHERE c.parent_key = s.key), 0))"
+                }
+                SortKey::Created => "s.created_at",
+                SortKey::Messages => {
+                    "s.message_count + COALESCE((SELECT SUM(c.message_count) FROM sessions c WHERE c.parent_key = s.key), 0)"
+                }
+            }
+        } else {
+            match f.sort {
+                SortKey::Updated => "s.updated_at",
+                SortKey::Created => "s.created_at",
+                SortKey::Messages => "s.message_count",
+            }
         };
         let order_dir = if f.ascending { "ASC" } else { "DESC" };
 
@@ -340,13 +411,129 @@ impl Store {
         Ok(conn.query_row(&sql, params![key], row_to_meta).optional()?)
     }
 
-    pub fn list_projects(&self) -> Result<Vec<ProjectInfo>> {
+    /// 旁写父子链。只写差异,避免 watcher 每批空转 WAL。返回是否有变化。
+    pub fn apply_parent_links(&self, agent: AgentId, links: &[(String, String)]) -> Result<bool> {
+        let desired: HashMap<String, String> = links.iter().cloned().collect();
+        let mut conn = self.write.lock().unwrap();
+        let existing: HashMap<String, String> = {
+            let mut stmt = conn.prepare(
+                "SELECT key, parent_key FROM sessions WHERE agent_id = ?1 AND parent_key != ''",
+            )?;
+            let rows = stmt.query_map(params![agent.as_str()], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            })?;
+            let mut map = HashMap::new();
+            for row in rows {
+                let (k, v) = row?;
+                map.insert(k, v);
+            }
+            map
+        };
+        let mut changed = false;
+        let tx = conn.transaction()?;
+        for (key, pk) in &existing {
+            if desired.get(key) != Some(pk) {
+                tx.execute(
+                    "UPDATE sessions SET parent_key = '' WHERE key = ?1",
+                    params![key],
+                )?;
+                changed = true;
+            }
+        }
+        for (key, pk) in &desired {
+            if existing.get(key) != Some(pk) {
+                let n = tx.execute(
+                    "UPDATE sessions SET parent_key = ?1 WHERE key = ?2 AND agent_id = ?3",
+                    params![pk, key, agent.as_str()],
+                )?;
+                if n > 0 {
+                    changed = true;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(changed)
+    }
+
+    pub fn list_children(
+        &self,
+        parent_key: &str,
+        sort: SortKey,
+        ascending: bool,
+    ) -> Result<Vec<SessionMeta>> {
+        let order_col = match sort {
+            SortKey::Updated => "s.updated_at",
+            SortKey::Created => "s.created_at",
+            SortKey::Messages => "s.message_count",
+        };
+        let order_dir = if ascending { "ASC" } else { "DESC" };
+        let conn = self.read.lock().unwrap();
+        let sql = format!(
+            "SELECT {SESSION_COLS} FROM sessions s LEFT JOIN user_data u ON u.session_key = s.key
+             WHERE s.parent_key = ?1 AND s.archived = 0
+             ORDER BY COALESCE(u.pinned,0) DESC, {order_col} {order_dir}"
+        );
+        let mut stmt = conn.prepare_cached(&sql)?;
+        let rows = stmt.query_map(params![parent_key], row_to_meta)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// 某会话下全部子会话(含 archived),删除主会话时一并带走。
+    pub fn all_children(&self, parent_key: &str) -> Result<Vec<SessionMeta>> {
+        let conn = self.read.lock().unwrap();
+        let sql = format!(
+            "SELECT {SESSION_COLS} FROM sessions s LEFT JOIN user_data u ON u.session_key = s.key
+             WHERE s.parent_key = ?1"
+        );
+        let mut stmt = conn.prepare_cached(&sql)?;
+        let rows = stmt.query_map(params![parent_key], row_to_meta)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    pub fn child_counts(&self) -> Result<HashMap<String, i64>> {
         let conn = self.read.lock().unwrap();
         let mut stmt = conn.prepare_cached(
-            "SELECT project_path, project_name, COUNT(*), MAX(updated_at)
-             FROM sessions WHERE archived = 0
-             GROUP BY project_path ORDER BY MAX(updated_at) DESC",
+            "SELECT parent_key, COUNT(*) FROM sessions WHERE parent_key != '' AND archived = 0 GROUP BY parent_key",
         )?;
+        let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?;
+        let mut map = HashMap::new();
+        for row in rows {
+            let (k, n) = row?;
+            map.insert(k, n);
+        }
+        Ok(map)
+    }
+
+    pub fn parent_key_of(&self, key: &str) -> Result<Option<String>> {
+        let conn = self.read.lock().unwrap();
+        let raw: Option<String> = conn
+            .query_row(
+                "SELECT parent_key FROM sessions WHERE key = ?1",
+                params![key],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(raw.filter(|s| !s.is_empty()))
+    }
+
+    pub fn list_projects(&self) -> Result<Vec<ProjectInfo>> {
+        let conn = self.read.lock().unwrap();
+        // 个数只数顶层(与点开后列表一致);last_active 仍看整组,子会话活动会把项目顶上来
+        let mut stmt = conn.prepare_cached(&format!(
+            "SELECT s.project_path, s.project_name,
+                    SUM(CASE WHEN {ROOT_WHEN_HIDING_ARCHIVED} THEN 1 ELSE 0 END),
+                    MAX(s.updated_at)
+             FROM sessions s WHERE s.archived = 0
+             GROUP BY s.project_path ORDER BY MAX(s.updated_at) DESC",
+        ))?;
         let rows = stmt.query_map([], |r| {
             Ok(ProjectInfo {
                 path: r.get(0)?,
@@ -365,7 +552,7 @@ impl Store {
     pub fn starred_count(&self) -> Result<i64> {
         let conn = self.read.lock().unwrap();
         Ok(conn.query_row(
-            // archived 过滤与 agent_counts/list_projects 同口径,徽标数 = 点开后可见数
+            // 收藏是扁平列表(含子会话),徽标数 = 点开后可见数
             "SELECT COUNT(*) FROM user_data u JOIN sessions s ON s.key = u.session_key WHERE u.favorite = 1 AND s.archived = 0",
             [],
             |r| r.get(0),
@@ -374,8 +561,11 @@ impl Store {
 
     pub fn agent_counts(&self) -> Result<HashMap<String, i64>> {
         let conn = self.read.lock().unwrap();
-        let mut stmt =
-            conn.prepare_cached("SELECT agent_id, COUNT(*) FROM sessions WHERE archived = 0 GROUP BY agent_id")?;
+        let mut stmt = conn.prepare_cached(&format!(
+            "SELECT s.agent_id, COUNT(*) FROM sessions s
+             WHERE s.archived = 0 AND {ROOT_WHEN_HIDING_ARCHIVED}
+             GROUP BY s.agent_id",
+        ))?;
         let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?;
         let mut map = HashMap::new();
         for r in rows {
@@ -488,7 +678,14 @@ impl Store {
                 },
             )?;
             for r in rows {
-                let (k, seq, sc, role, ts, text): (String, i64, Option<String>, String, Option<i64>, String) = r?;
+                let (k, seq, sc, role, ts, text): (
+                    String,
+                    i64,
+                    Option<String>,
+                    String,
+                    Option<i64>,
+                    String,
+                ) = r?;
                 raw.push((k, seq, sc, role, ts, make_like_snippet(&text, segs[0])));
             }
         }
@@ -514,7 +711,13 @@ impl Store {
     }
 }
 
-const SESSION_COLS: &str = "s.key, s.agent_id, s.native_id, s.title, s.project_path, s.project_name,
+/// 顶层行:无父,或父不在未归档集合里(orphan 仍可见)。侧栏计数与 roots_only 列表同口径。
+const ROOT_WHEN_HIDING_ARCHIVED: &str = "(s.parent_key = '' OR NOT EXISTS (SELECT 1 FROM sessions p WHERE p.key = s.parent_key AND p.archived = 0))";
+const ROOT_IGNORING_ARCHIVED: &str =
+    "(s.parent_key = '' OR NOT EXISTS (SELECT 1 FROM sessions p WHERE p.key = s.parent_key))";
+
+const SESSION_COLS: &str =
+    "s.key, s.agent_id, s.native_id, s.title, s.project_path, s.project_name,
     s.git_branch, s.created_at, s.updated_at, s.message_count, s.tokens_used, s.model, s.source,
     s.archived, s.file_path, s.file_size, COALESCE(u.favorite,0), COALESCE(u.pinned,0)";
 
@@ -580,7 +783,9 @@ fn upsert_session(tx: &rusqlite::Transaction<'_>, m: &SessionMeta, file_mtime: i
 }
 
 fn escape_like(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 fn make_like_snippet(text: &str, first_seg: &str) -> String {

--- a/crates/wake-core/src/lib.rs
+++ b/crates/wake-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod adapters;
 pub mod db;
 pub mod models;
+pub mod nest;
 pub mod scanner;
 pub mod services;
 pub mod watcher;

--- a/crates/wake-core/src/models.rs
+++ b/crates/wake-core/src/models.rs
@@ -51,7 +51,7 @@ impl AgentId {
             "grok" => Some(AgentId::Grok),
             "kimi" => Some(AgentId::Kimi),
             "antigravity" => Some(AgentId::Antigravity),
-        _ => None,
+            _ => None,
         }
     }
 
@@ -82,30 +82,53 @@ impl AgentId {
             AgentId::ClaudeCode => "brands/claude-code.png",
             AgentId::Codex => "brands/codex.png",
             AgentId::Copilot => {
-                if dark { "brands/copilot.png" } else { "brands/copilot-light.png" }
+                if dark {
+                    "brands/copilot.png"
+                } else {
+                    "brands/copilot-light.png"
+                }
             }
             AgentId::Cursor => {
-                if dark { "brands/cursor.png" } else { "brands/cursor-light.png" }
+                if dark {
+                    "brands/cursor.png"
+                } else {
+                    "brands/cursor-light.png"
+                }
             }
             AgentId::Opencode => {
-                if dark { "brands/opencode.png" } else { "brands/opencode-light.png" }
+                if dark {
+                    "brands/opencode.png"
+                } else {
+                    "brands/opencode-light.png"
+                }
             }
             AgentId::Kiro => "brands/kiro.png",
             AgentId::Gemini => "brands/gemini.png",
             AgentId::Pi => {
-                if dark { "brands/pi.png" } else { "brands/pi-light.png" }
+                if dark {
+                    "brands/pi.png"
+                } else {
+                    "brands/pi-light.png"
+                }
             }
             AgentId::Omp => "brands/omp.png",
             AgentId::Grok => {
-                if dark { "brands/grok.png" } else { "brands/grok-light.png" }
+                if dark {
+                    "brands/grok.png"
+                } else {
+                    "brands/grok-light.png"
+                }
             }
             AgentId::Kimi => {
-                if dark { "brands/kimi.png" } else { "brands/kimi-light.png" }
+                if dark {
+                    "brands/kimi.png"
+                } else {
+                    "brands/kimi-light.png"
+                }
             }
             AgentId::Antigravity => "brands/antigravity.png",
         }
     }
-
 }
 
 /// 会话元数据 —— 列表页/索引库统一模型
@@ -133,6 +156,17 @@ pub struct SessionMeta {
     // app 自有状态(user_data 表)
     pub favorite: bool,
     pub pinned: bool,
+}
+
+/// 会话列表一行:顶层或挂在主会话下的子代理
+#[derive(Debug, Clone)]
+pub struct SessionRow {
+    pub meta: SessionMeta,
+    /// 0 = 顶层,1 = 挂在主会话下
+    pub depth: u8,
+    /// 顶层会话收纳的子代理数;0 表示没有可展开的子级
+    pub child_count: usize,
+    pub expanded: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -262,6 +296,8 @@ pub struct SessionFilter {
     pub ascending: bool,
     pub limit: i64,
     pub offset: i64,
+    /// true = 只返回顶层(父不存在时孩子仍可见);搜索/收藏走扁平
+    pub roots_only: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/wake-core/src/nest.rs
+++ b/crates/wake-core/src/nest.rs
@@ -1,0 +1,110 @@
+//! 把已按 SQL 取好的顶层会话与孩子拼成可展开列表。
+use crate::models::*;
+use std::collections::{HashMap, HashSet};
+
+pub fn nest_session_rows(
+    roots: Vec<SessionMeta>,
+    child_counts: &HashMap<String, i64>,
+    children: &HashMap<String, Vec<SessionMeta>>,
+    expanded: &HashSet<String>,
+) -> Vec<SessionRow> {
+    let mut out = Vec::new();
+    for root in roots {
+        let child_count = child_counts.get(&root.key).copied().unwrap_or(0) as usize;
+        let is_expanded = child_count > 0 && expanded.contains(&root.key);
+        let key = root.key.clone();
+        out.push(SessionRow {
+            meta: root,
+            depth: 0,
+            child_count,
+            expanded: is_expanded,
+        });
+        if is_expanded {
+            if let Some(kids) = children.get(&key) {
+                for kid in kids {
+                    out.push(SessionRow {
+                        meta: kid.clone(),
+                        depth: 1,
+                        child_count: 0,
+                        expanded: false,
+                    });
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(key: &str, title: &str) -> SessionMeta {
+        SessionMeta {
+            key: key.into(),
+            id: key.split(':').nth(1).unwrap_or(key).into(),
+            agent: AgentId::Grok,
+            title: title.into(),
+            project_path: "/p".into(),
+            project_name: "Grok".into(),
+            file_path: format!("/{key}"),
+            created_at: 1,
+            updated_at: 1,
+            message_count: 1,
+            size_bytes: 1,
+            git_branch: None,
+            model: None,
+            tokens_used: None,
+            archived: false,
+            source: None,
+            favorite: false,
+            pinned: false,
+        }
+    }
+
+    #[test]
+    fn collapsed_hides_children() {
+        let roots = vec![s("grok:orch", "调研终端"), s("grok:other", "别的")];
+        let mut counts = HashMap::new();
+        counts.insert("grok:orch".into(), 2);
+        let mut children = HashMap::new();
+        children.insert(
+            "grok:orch".into(),
+            vec![s("grok:c1", "A"), s("grok:c2", "B")],
+        );
+        let rows = nest_session_rows(roots, &counts, &children, &HashSet::new());
+        let titles: Vec<_> = rows.iter().map(|r| r.meta.title.as_str()).collect();
+        assert_eq!(titles, vec!["调研终端", "别的"]);
+        assert_eq!(rows[0].child_count, 2);
+        assert!(!rows[0].expanded);
+    }
+
+    #[test]
+    fn expanded_inserts_children_below_parent() {
+        let roots = vec![s("grok:orch", "调研终端")];
+        let mut counts = HashMap::new();
+        counts.insert("grok:orch".into(), 2);
+        let mut children = HashMap::new();
+        children.insert(
+            "grok:orch".into(),
+            vec![s("grok:c1", "A"), s("grok:c2", "B")],
+        );
+        let mut open = HashSet::new();
+        open.insert("grok:orch".into());
+        let rows = nest_session_rows(roots, &counts, &children, &open);
+        let titles: Vec<_> = rows
+            .iter()
+            .map(|r| (r.meta.title.as_str(), r.depth))
+            .collect();
+        assert_eq!(titles, vec![("调研终端", 0), ("A", 1), ("B", 1)]);
+        assert!(rows[0].expanded);
+    }
+
+    #[test]
+    fn flat_mode_no_chevrons_when_counts_empty() {
+        let roots = vec![s("grok:c", "orphan"), s("grok:orch", "调研终端")];
+        let rows = nest_session_rows(roots, &HashMap::new(), &HashMap::new(), &HashSet::new());
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.depth == 0 && r.child_count == 0));
+    }
+}

--- a/crates/wake-core/src/scanner.rs
+++ b/crates/wake-core/src/scanner.rs
@@ -89,6 +89,7 @@ fn run_scan_inner(
     let mut queue: Vec<WorkItem> = Vec::new();
 
     for adapter in adapters {
+        adapter.begin_scan();
         let refs: Vec<SessionFileRef> = adapter
             .list_session_files()?
             .into_iter()
@@ -129,7 +130,9 @@ fn run_scan_inner(
                 Some((mtime, size, _)) => *mtime != r.mtime_ms || *size != r.size,
             };
             if full || changed {
-                let quick = quick_map.as_ref().and_then(|m| m.get(&r.file_path).cloned());
+                let quick = quick_map
+                    .as_ref()
+                    .and_then(|m| m.get(&r.file_path).cloned());
                 queue.push(WorkItem {
                     adapter: adapter.as_ref(),
                     r,
@@ -175,6 +178,12 @@ fn run_scan_inner(
         }
     }
 
+    for adapter in adapters {
+        if store.apply_parent_links(adapter.agent(), &adapter.parent_links())? {
+            events.on_sessions_changed();
+        }
+    }
+
     Ok(())
 }
 
@@ -203,6 +212,7 @@ pub fn scan_files(
         let Some(adapter) = adapters.iter().find(|a| a.agent() == agent) else {
             continue;
         };
+        adapter.begin_scan();
         let quick = adapter.quick_meta(&group);
         for r in &group {
             match adapter.parse_session(r) {
@@ -211,12 +221,20 @@ pub fn scan_files(
                         Some(q) => adapter.merge_quick_meta(parsed.meta, q),
                         None => parsed.meta,
                     };
-                    if store.write_session(&meta, r.mtime_ms, &parsed.units).is_ok() {
+                    if store
+                        .write_session(&meta, r.mtime_ms, &parsed.units)
+                        .is_ok()
+                    {
                         changed = true;
                     }
                 }
                 Err(e) => eprintln!("[scanner] incremental parse failed {}: {e}", r.file_path),
             }
+        }
+        match store.apply_parent_links(agent, &adapter.parent_links()) {
+            Ok(true) => changed = true,
+            Ok(false) => {}
+            Err(e) => eprintln!("[scanner] parent links failed: {e}"),
         }
     }
     if changed {

--- a/crates/wake-core/tests/adapter_contracts.rs
+++ b/crates/wake-core/tests/adapter_contracts.rs
@@ -92,6 +92,15 @@ fn setup() -> &'static TestEnv {
         .expect("write kimi session_index");
 
         std::env::set_var("HOME", home.path());
+        if let Some(data) = dirs::data_dir() {
+            build_cursor_titles_db(
+                &data
+                    .join("Cursor")
+                    .join("User")
+                    .join("globalStorage")
+                    .join("conversation-search.db"),
+            );
+        }
         TestEnv {
             copilot_db,
             opencode_db,
@@ -125,6 +134,24 @@ fn build_copilot_db(path: &Path) {
         "#,
     )
     .expect("populate copilot fixture db");
+}
+
+/// Cursor IDE 改名写在 conversation-search.db,id 对齐 agent-transcript uuid
+fn build_cursor_titles_db(path: &Path) {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).expect("mkdir cursor titles dir");
+    }
+    let conn = rusqlite::Connection::open(path).expect("create cursor titles db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE conversations (
+            id TEXT PRIMARY KEY, title TEXT
+        );
+        INSERT INTO conversations VALUES
+            ('33333333-aaaa-bbbb-cccc-000000000003', 'Cursor QR 组件');
+        "#,
+    )
+    .expect("populate cursor titles db");
 }
 
 /// OpenCode `opencode.db` 最小同构库,v1 与 v2 两代表并存(v2 迁移后形态):
@@ -503,11 +530,8 @@ fn cursor_parse_contract() {
         .parse_transcript(&r)
         .expect("cursor parse_transcript");
 
-    // 标题取 <user_query> 壳内正文;无壳的注入行(<workspace>)归 Meta 被跳过
-    assert_eq!(
-        s.meta.title,
-        "把二维码扫描组件抽出来,注意 useEffect() 的清理"
-    );
+    // 标题取 Cursor IDE conversation-search.db 的 rename,压过 jsonl 首条
+    assert_eq!(s.meta.title, "Cursor QR 组件");
     // slug 目录 "wakefx-cursor-proj" 磁盘上无对应真实路径 → 直译回退
     assert_eq!(s.meta.project_path, "/wakefx/cursor/proj");
     assert_eq!(s.meta.project_name, "proj");

--- a/crates/wake-core/tests/adapter_contracts.rs
+++ b/crates/wake-core/tests/adapter_contracts.rs
@@ -210,13 +210,16 @@ fn build_antigravity_db(path: &Path) {
 // ---------------------------------------------------------------- 小工具
 
 fn fixture(rel: &str) -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(rel)
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(rel)
 }
 
 /// 文件型 agent 的 SessionFileRef(直接指 fixture,不走 list_session_files)
 fn fs_ref(agent: AgentId, path: &Path, native_id: &str) -> SessionFileRef {
-    let meta = fs::metadata(path)
-        .unwrap_or_else(|e| panic!("fixture missing {}: {e}", path.display()));
+    let meta =
+        fs::metadata(path).unwrap_or_else(|e| panic!("fixture missing {}: {e}", path.display()));
     SessionFileRef {
         agent,
         native_id: native_id.to_string(),
@@ -243,7 +246,9 @@ fn db_ref(agent: AgentId, db: &Path, id: &str) -> SessionFileRef {
 }
 
 fn ms(rfc3339: &str) -> i64 {
-    chrono::DateTime::parse_from_rfc3339(rfc3339).expect("test timestamp").timestamp_millis()
+    chrono::DateTime::parse_from_rfc3339(rfc3339)
+        .expect("test timestamp")
+        .timestamp_millis()
 }
 
 fn roles_kinds(mainline: &[TranscriptMessage]) -> Vec<(Role, MessageKind)> {
@@ -317,7 +322,9 @@ fn claude_parse_contract() {
     let adapter = ClaudeAdapter::new();
     let r = claude_ref();
     let s = adapter.parse_session(&r).expect("claude parse_session");
-    let t = adapter.parse_transcript(&r).expect("claude parse_transcript");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("claude parse_transcript");
 
     // 标题=最后一条 custom-title,压过首条用户消息推导
     assert_eq!(s.meta.title, "QR login revamp");
@@ -351,11 +358,18 @@ fn claude_parse_contract() {
     assert_eq!(a.tool_calls.len(), 1);
     assert_eq!(a.tool_calls[0].name, "Read");
     // tool_result 在后续 user 行,应回填到 tool_use
-    assert!(a.tool_calls[0].output.as_deref().unwrap_or_default().contains("useEffect"));
+    assert!(a.tool_calls[0]
+        .output
+        .as_deref()
+        .unwrap_or_default()
+        .contains("useEffect"));
     assert!(!a.tool_calls[0].is_error);
 
     // units 只含 Text 消息,tool 名与 input 摘要并入正文
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![1, 2, 3]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
     assert!(s.units[1].text.contains("Login.tsx"));
 
     // 无真实用户消息的变体 → UNTITLED
@@ -364,7 +378,9 @@ fn claude_parse_contract() {
         &fixture("claude/projects/-Users-tester-Github-wakefx/aaaaaaaa-0000-4000-8000-00000000000a.jsonl"),
         "aaaaaaaa-0000-4000-8000-00000000000a",
     );
-    let s2 = adapter.parse_session(&untitled).expect("claude untitled parse");
+    let s2 = adapter
+        .parse_session(&untitled)
+        .expect("claude untitled parse");
     assert_eq!(s2.meta.title, UNTITLED);
     assert_eq!(s2.meta.message_count, 1);
 }
@@ -379,7 +395,9 @@ fn codex_parse_contract() {
     assert_eq!(r.native_id, "22222222-aaaa-bbbb-cccc-000000000002");
 
     let s = adapter.parse_session(&r).expect("codex parse_session");
-    let t = adapter.parse_transcript(&r).expect("codex parse_transcript");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("codex parse_transcript");
 
     // 标题取首条真实用户消息(environment_context 注入行归 Meta 被跳过)
     assert_eq!(s.meta.title, "扫码登录报错,帮我查一下 useEffect() 依赖数组");
@@ -413,10 +431,17 @@ fn codex_parse_contract() {
     assert!(!thinking.contains("OPAQUE-CIPHERTEXT"));
     assert_eq!(host.tool_calls.len(), 1);
     assert_eq!(host.tool_calls[0].name, "shell");
-    assert!(host.tool_calls[0].output.as_deref().unwrap_or_default().contains("QrScanner"));
+    assert!(host.tool_calls[0]
+        .output
+        .as_deref()
+        .unwrap_or_default()
+        .contains("QrScanner"));
 
     // 空文本的 reasoning 宿主凭 tool call 进入 units
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![1, 2, 3]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
 }
 
 #[test]
@@ -425,7 +450,9 @@ fn copilot_parse_contract() {
     let adapter = CopilotAdapter::new();
     let r = db_ref(AgentId::Copilot, &env.copilot_db, "cop-0001");
     let s = adapter.parse_session(&r).expect("copilot parse_session");
-    let t = adapter.parse_transcript(&r).expect("copilot parse_transcript");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("copilot parse_transcript");
 
     assert_eq!(s.meta.title, "Copilot QR fix"); // summary 优先
     assert_eq!(s.meta.git_branch.as_deref(), Some("main"));
@@ -446,7 +473,10 @@ fn copilot_parse_contract() {
         ]
     );
     assert_eq!(t.mainline[0].timestamp, Some(ms("2026-08-05T09:05:00Z")));
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![0, 1, 2]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![0, 1, 2]
+    );
 
     // summary 为空的会话回退首条用户消息作标题
     let r2 = db_ref(AgentId::Copilot, &env.copilot_db, "cop-0002");
@@ -461,10 +491,15 @@ fn cursor_parse_contract() {
     let adapter = CursorAdapter::new();
     let r = cursor_ref();
     let s = adapter.parse_session(&r).expect("cursor parse_session");
-    let t = adapter.parse_transcript(&r).expect("cursor parse_transcript");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("cursor parse_transcript");
 
     // 标题取 <user_query> 壳内正文;无壳的注入行(<workspace>)归 Meta 被跳过
-    assert_eq!(s.meta.title, "把二维码扫描组件抽出来,注意 useEffect() 的清理");
+    assert_eq!(
+        s.meta.title,
+        "把二维码扫描组件抽出来,注意 useEffect() 的清理"
+    );
     // slug 目录 "wakefx-cursor-proj" 磁盘上无对应真实路径 → 直译回退
     assert_eq!(s.meta.project_path, "/wakefx/cursor/proj");
     assert_eq!(s.meta.project_name, "proj");
@@ -482,12 +517,18 @@ fn cursor_parse_contract() {
             (Role::User, MessageKind::Text),
         ]
     );
-    assert_eq!(t.mainline[1].timestamp, Some(ms("2026-08-01T09:30:00+08:00")));
+    assert_eq!(
+        t.mainline[1].timestamp,
+        Some(ms("2026-08-01T09:30:00+08:00"))
+    );
     let a = &t.mainline[2];
     assert_eq!(a.tool_calls.len(), 1);
     assert_eq!(a.tool_calls[0].name, "read_file");
     assert_eq!(a.tool_calls[0].output, None); // transcript 不落盘工具结果
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![1, 2, 3]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
 }
 
 #[test]
@@ -496,7 +537,9 @@ fn opencode_parse_contract() {
     let adapter = OpencodeAdapter::new();
     let r = db_ref(AgentId::Opencode, &env.opencode_db, "oc-0001");
     let s = adapter.parse_session(&r).expect("opencode parse_session");
-    let t = adapter.parse_transcript(&r).expect("opencode parse_transcript");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("opencode parse_transcript");
 
     assert_eq!(s.meta.title, "OpenCode 二维码排查"); // session 表自带标题
     assert_eq!(s.meta.project_name, "wakefx");
@@ -517,12 +560,23 @@ fn opencode_parse_contract() {
         ]
     );
     let a = &t.mainline[2];
-    assert!(a.thinking.as_deref().unwrap_or_default().contains("先查 effect 依赖"));
+    assert!(a
+        .thinking
+        .as_deref()
+        .unwrap_or_default()
+        .contains("先查 effect 依赖"));
     assert_eq!(a.tool_calls.len(), 1);
     assert_eq!(a.tool_calls[0].name, "grep");
-    assert!(a.tool_calls[0].output.as_deref().unwrap_or_default().contains("QrScanner"));
+    assert!(a.tool_calls[0]
+        .output
+        .as_deref()
+        .unwrap_or_default()
+        .contains("QrScanner"));
     assert!(!a.tool_calls[0].is_error);
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![1, 2]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
 }
 
 #[test]
@@ -544,12 +598,18 @@ fn kiro_parse_contract() {
 
     assert_eq!(
         roles_kinds(&t.mainline),
-        vec![(Role::User, MessageKind::Text), (Role::Assistant, MessageKind::Text)]
+        vec![
+            (Role::User, MessageKind::Text),
+            (Role::Assistant, MessageKind::Text)
+        ]
     );
     // jsonl 的 timestamp 是 unix 秒,应换算成 ms
     assert_eq!(t.mainline[0].timestamp, Some(1785744300000));
     assert_eq!(t.mainline[1].timestamp, Some(1785744360000));
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![0, 1]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
 }
 
 #[test]
@@ -558,14 +618,19 @@ fn gemini_parse_contract() {
     let adapter = GeminiAdapter::new();
     let r = gemini_ref();
     let s = adapter.parse_session(&r).expect("gemini parse_session");
-    let t = adapter.parse_transcript(&r).expect("gemini parse_transcript");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("gemini parse_transcript");
 
     // $set 是覆盖式快照:只认最后一条,旧快照文本不得出现
     assert_eq!(t.mainline.len(), 2);
     assert!(t.mainline.iter().all(|m| !m.text.contains("旧快照")));
     assert_eq!(
         roles_kinds(&t.mainline),
-        vec![(Role::User, MessageKind::Text), (Role::Assistant, MessageKind::Text)]
+        vec![
+            (Role::User, MessageKind::Text),
+            (Role::Assistant, MessageKind::Text)
+        ]
     );
 
     // id 取 header 的 sessionId(非文件名 stem)
@@ -578,7 +643,10 @@ fn gemini_parse_contract() {
     assert_eq!(s.meta.updated_at, ms("2026-08-04T12:20:00Z"));
     assert_eq!(s.meta.message_count, 2);
     assert_eq!(s.unknown_line_count, 1);
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![0, 1]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
 }
 
 #[test]
@@ -597,8 +665,12 @@ fn opencode_v2_parse_contract() {
     assert!(ids.contains("oc-0001"), "仅存于 v1 表的会话应被 UNION 回捞");
 
     let r = db_ref(AgentId::Opencode, &env.opencode_db, "ocv2-0001");
-    let s = adapter.parse_session(&r).expect("opencode v2 parse_session");
-    let t = adapter.parse_transcript(&r).expect("opencode v2 parse_transcript");
+    let s = adapter
+        .parse_session(&r)
+        .expect("opencode v2 parse_session");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("opencode v2 parse_transcript");
 
     assert_eq!(s.meta.title, "OpenCode v2 greeting");
     assert_eq!(s.meta.model.as_deref(), Some("nemotron-3.5-lightning-free"));
@@ -620,9 +692,16 @@ fn opencode_v2_parse_contract() {
     assert_eq!(t.mainline[0].text, "OpenCode v2 看看二维码组件");
     let a = &t.mainline[2];
     assert_eq!(a.text, "看完了,组件没有泄漏。");
-    assert!(a.thinking.as_deref().unwrap_or_default().contains("扫描组件"));
+    assert!(a
+        .thinking
+        .as_deref()
+        .unwrap_or_default()
+        .contains("扫描组件"));
     assert_eq!(a.model.as_deref(), Some("nemotron-3.5-lightning-free"));
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![0, 2]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![0, 2]
+    );
 
     // 仅存于 v1 表的会话不带 v2 标记(resume 走 v1 二进制)
     let s1 = adapter
@@ -658,20 +737,32 @@ fn pi_parse_contract() {
     // 连续 assistant 行(中间只隔 toolResult)合并成一条
     assert_eq!(
         roles_kinds(&t.mainline),
-        vec![(Role::User, MessageKind::Text), (Role::Assistant, MessageKind::Text)]
+        vec![
+            (Role::User, MessageKind::Text),
+            (Role::Assistant, MessageKind::Text)
+        ]
     );
     let a = &t.mainline[1];
     assert_eq!(a.text, "找到泄漏点,已补清理回调。");
     assert_eq!(a.tool_calls.len(), 1);
     assert_eq!(a.tool_calls[0].name, "bash");
     // toolResult 是独立 role 行,按 toolCallId 回填
-    assert!(a.tool_calls[0].output.as_deref().unwrap_or_default().contains("QrScanner"));
+    assert!(a.tool_calls[0]
+        .output
+        .as_deref()
+        .unwrap_or_default()
+        .contains("QrScanner"));
     assert!(!a.tool_calls[0].is_error);
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![0, 1]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
 
     // omp 是 pi 的 fork,同一解析核心,只有 key 前缀不同
     let omp = PiAdapter::omp();
-    let s2 = omp.parse_session(&pi_ref(AgentId::Omp)).expect("omp parse_session");
+    let s2 = omp
+        .parse_session(&pi_ref(AgentId::Omp))
+        .expect("omp parse_session");
     assert_eq!(s2.meta.agent, AgentId::Omp);
     assert_eq!(s2.meta.key, "omp:66666666-aaaa-bbbb-cccc-000000000006");
     assert_eq!(s2.meta.title, "Pi 查一下二维码组件的 useEffect() 清理");
@@ -685,7 +776,9 @@ fn grok_parse_contract() {
     let path = fixture("grok/sessions/%2FUsers%2Ftester%2FGithub%2Fwakefx/77777777-aaaa-bbbb-cccc-000000000007/updates.jsonl");
     let r = adapter.file_ref(&path).expect("grok file_ref");
     assert_eq!(r.native_id, "77777777-aaaa-bbbb-cccc-000000000007");
-    assert!(adapter.file_ref(&path.with_file_name("chat_history.jsonl")).is_none());
+    assert!(adapter
+        .file_ref(&path.with_file_name("chat_history.jsonl"))
+        .is_none());
 
     let s = adapter.parse_session(&r).expect("grok parse_session");
     let t = adapter.parse_transcript(&r).expect("grok parse_transcript");
@@ -702,19 +795,93 @@ fn grok_parse_contract() {
     // chunk 流按角色段合并:两条 user chunk 拼成一条,thought/message/tool 全并入一条 assistant
     assert_eq!(
         roles_kinds(&t.mainline),
-        vec![(Role::User, MessageKind::Text), (Role::Assistant, MessageKind::Text)]
+        vec![
+            (Role::User, MessageKind::Text),
+            (Role::Assistant, MessageKind::Text)
+        ]
     );
-    assert_eq!(t.mainline[0].text, "Grok 看看二维码扫描,重点 useEffect() 清理");
+    assert_eq!(
+        t.mainline[0].text,
+        "Grok 看看二维码扫描,重点 useEffect() 清理"
+    );
     assert_eq!(t.mainline[0].timestamp, Some(1786014300000));
     let a = &t.mainline[1];
     assert_eq!(a.text, "已定位泄漏,补了清理回调。");
-    assert!(a.thinking.as_deref().unwrap_or_default().contains("effect 泄漏"));
+    assert!(a
+        .thinking
+        .as_deref()
+        .unwrap_or_default()
+        .contains("effect 泄漏"));
     assert_eq!(a.tool_calls.len(), 1);
     assert_eq!(a.tool_calls[0].name, "Grep");
     // tool_call_update 的 content 文本回填 output;字节数组 rawOutput 不碰
-    assert!(a.tool_calls[0].output.as_deref().unwrap_or_default().contains("found 2 matches"));
+    assert!(a.tool_calls[0]
+        .output
+        .as_deref()
+        .unwrap_or_default()
+        .contains("found 2 matches"));
     assert!(!a.tool_calls[0].is_error);
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![0, 1]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+}
+
+#[test]
+fn grok_worktree_session_groups_under_parent_project() {
+    setup();
+    let adapter = GrokAdapter::new();
+    let path =
+        fixture("grok/sessions/wt-ephemeral/aaaaaaaa-aaaa-bbbb-cccc-0000000000aa/updates.jsonl");
+    let r = adapter.file_ref(&path).expect("grok worktree file_ref");
+    let s = adapter.parse_session(&r).expect("grok worktree parse");
+    // cwd 是 /var/folders/.../wt-abcd1234-pr-9,但 git_remotes 指向 wakefx.origin.git
+    // → 归进父项目 wakefx,与普通 grok 会话同一分组键
+    assert_eq!(s.meta.project_path, "/Users/tester/Github/wakefx");
+    assert_eq!(s.meta.project_name, "wakefx");
+    assert_eq!(
+        s.meta.git_branch.as_deref(),
+        Some("execute-plan/abcd1234-pr-9-feat-example")
+    );
+    assert_eq!(s.meta.title, "Grok worktree review");
+}
+
+#[test]
+fn grok_subagent_groups_under_orchestrator_project() {
+    setup();
+    let home = std::env::var("HOME").expect("HOME");
+    let child_id = "cccccccc-aaaa-bbbb-cccc-0000000000cc";
+    let meta_dir = std::path::Path::new(&home)
+        .join(".grok/sessions/%2FUsers%2Ftester%2FDesktop%2FAI%2FGrok")
+        .join("orch-id")
+        .join("subagents")
+        .join(child_id);
+    fs::create_dir_all(&meta_dir).expect("mkdir parent subagents");
+    fs::write(
+        meta_dir.join("meta.json"),
+        format!(
+            r#"{{"parent_session_id":"orch-id","child_session_id":"{child_id}","subagent_id":"{child_id}"}}"#
+        ),
+    )
+    .expect("write meta.json");
+
+    let adapter = GrokAdapter::new();
+    adapter.begin_scan();
+    let child_key = format!("grok:{child_id}");
+    assert!(
+        adapter
+            .parent_links()
+            .iter()
+            .any(|(c, p)| c == &child_key && p == "grok:orch-id"),
+        "parent_links should include orchestrator edge"
+    );
+    let path =
+        fixture("grok/sessions/wt-parented/cccccccc-aaaa-bbbb-cccc-0000000000cc/updates.jsonl");
+    let r = adapter.file_ref(&path).expect("grok parented file_ref");
+    let s = adapter.parse_session(&r).expect("grok parented parse");
+    // cwd 是临时 wt,无 git_remotes;主会话 subagents/meta 指向 Desktop/AI/Grok
+    assert_eq!(s.meta.project_path, "/Users/tester/Desktop/AI/Grok");
+    assert_eq!(s.meta.project_name, "Grok");
 }
 
 #[test]
@@ -730,7 +897,7 @@ fn kimi_parse_contract() {
     let t = adapter.parse_transcript(&r).expect("kimi parse_transcript");
 
     assert_eq!(s.meta.title, "Kimi QR fix"); // state.json 标题优先
-    // cwd 靠假 HOME 的 session_index.jsonl 反查(目录名 hash 不可反推)
+                                             // cwd 靠假 HOME 的 session_index.jsonl 反查(目录名 hash 不可反推)
     assert_eq!(s.meta.project_path, "/Users/tester/Github/wakefx");
     assert_eq!(s.meta.created_at, ms("2026-08-06T12:00:00Z"));
     assert_eq!(s.meta.updated_at, ms("2026-08-06T12:30:00Z"));
@@ -740,11 +907,20 @@ fn kimi_parse_contract() {
 
     assert_eq!(
         roles_kinds(&t.mainline),
-        vec![(Role::User, MessageKind::Text), (Role::Assistant, MessageKind::Text)]
+        vec![
+            (Role::User, MessageKind::Text),
+            (Role::Assistant, MessageKind::Text)
+        ]
     );
-    assert_eq!(t.mainline[0].text, "Kimi 修一下二维码组件的 useEffect() 内存泄漏");
+    assert_eq!(
+        t.mainline[0].text,
+        "Kimi 修一下二维码组件的 useEffect() 内存泄漏"
+    );
     assert!(t.mainline[1].text.contains("QrScanner"));
-    assert_eq!(s.units.iter().map(|u| u.seq).collect::<Vec<_>>(), vec![0, 1]);
+    assert_eq!(
+        s.units.iter().map(|u| u.seq).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
 
     // "New Session" 是占位标题,必须回退首条用户消息
     let placeholder = fs_ref(
@@ -752,7 +928,9 @@ fn kimi_parse_contract() {
         &fixture("kimi/sessions/wd_wakefx_abc123/session_99999999-aaaa-bbbb-cccc-000000000009/agents/main/wire.jsonl"),
         "session_99999999-aaaa-bbbb-cccc-000000000009",
     );
-    let s2 = adapter.parse_session(&placeholder).expect("kimi placeholder parse");
+    let s2 = adapter
+        .parse_session(&placeholder)
+        .expect("kimi placeholder parse");
     assert_eq!(s2.meta.title, "占位标题会话应回退到这句");
 }
 
@@ -767,8 +945,12 @@ fn antigravity_parse_contract() {
     assert_eq!(refs[0].native_id, "ag-0001");
 
     let r = db_ref(AgentId::Antigravity, &env.antigravity_db, "ag-0001");
-    let s = adapter.parse_session(&r).expect("antigravity parse_session");
-    let t = adapter.parse_transcript(&r).expect("antigravity parse_transcript");
+    let s = adapter
+        .parse_session(&r)
+        .expect("antigravity parse_session");
+    let t = adapter
+        .parse_transcript(&r)
+        .expect("antigravity parse_transcript");
 
     assert_eq!(s.meta.title, "QR overlay polish"); // 标题在 preview 列
     assert_eq!(s.meta.project_path, "/Users/tester/Github/wakefx"); // file:// URI 解码
@@ -779,7 +961,10 @@ fn antigravity_parse_contract() {
     assert!(s.meta.file_path.ends_with("#ag-0001")); // 虚拟路径
 
     // 正文加密:唯一一条 System 消息承载 preview 与说明,FTS 搜得到 preview
-    assert_eq!(roles_kinds(&t.mainline), vec![(Role::System, MessageKind::Text)]);
+    assert_eq!(
+        roles_kinds(&t.mainline),
+        vec![(Role::System, MessageKind::Text)]
+    );
     assert!(t.mainline[0].text.contains("QR overlay polish"));
     assert!(t.mainline[0].text.contains("encrypted"));
     assert_eq!(s.units.len(), 1);
@@ -792,18 +977,29 @@ fn antigravity_parse_contract() {
 /// 且 mainline seq 从 0 严格递增(搜索跳转按 seq 定位依赖此契约)。
 fn assert_seq_contract(adapter: &dyn AgentAdapter, r: &SessionFileRef) {
     let tag = r.agent.as_str();
-    let s = adapter.parse_session(r).unwrap_or_else(|e| panic!("[{tag}] parse_session: {e}"));
-    let t = adapter.parse_transcript(r).unwrap_or_else(|e| panic!("[{tag}] parse_transcript: {e}"));
+    let s = adapter
+        .parse_session(r)
+        .unwrap_or_else(|e| panic!("[{tag}] parse_session: {e}"));
+    let t = adapter
+        .parse_transcript(r)
+        .unwrap_or_else(|e| panic!("[{tag}] parse_transcript: {e}"));
 
     assert!(!t.mainline.is_empty(), "[{tag}] mainline 不应为空");
     for (i, m) in t.mainline.iter().enumerate() {
         assert_eq!(m.seq, i as i64, "[{tag}] mainline seq 必须从 0 严格递增");
     }
 
-    assert!(!s.units.is_empty(), "[{tag}] fixture 应产出至少一个 FTS 单元");
+    assert!(
+        !s.units.is_empty(),
+        "[{tag}] fixture 应产出至少一个 FTS 单元"
+    );
     let seqs: HashSet<i64> = t.mainline.iter().map(|m| m.seq).collect();
     for u in &s.units {
-        assert!(seqs.contains(&u.seq), "[{tag}] unit seq {} 在 mainline 中不存在", u.seq);
+        assert!(
+            seqs.contains(&u.seq),
+            "[{tag}] unit seq {} 在 mainline 中不存在",
+            u.seq
+        );
         let m = &t.mainline[u.seq as usize];
         assert_eq!(m.role, u.role, "[{tag}] seq {} 两侧角色不一致", u.seq);
     }
@@ -811,7 +1007,10 @@ fn assert_seq_contract(adapter: &dyn AgentAdapter, r: &SessionFileRef) {
     // 两条解析路径共用核心解析器,meta 关键字段必须一致
     assert_eq!(s.meta.key, t.meta.key, "[{tag}] key 两侧不一致");
     assert_eq!(s.meta.title, t.meta.title, "[{tag}] title 两侧不一致");
-    assert_eq!(s.meta.message_count, t.meta.message_count, "[{tag}] message_count 两侧不一致");
+    assert_eq!(
+        s.meta.message_count, t.meta.message_count,
+        "[{tag}] message_count 两侧不一致"
+    );
 }
 
 #[test]
@@ -820,16 +1019,25 @@ fn seq_contract_holds_for_all_agents() {
     let checks: Vec<(Box<dyn AgentAdapter>, SessionFileRef)> = vec![
         (Box::new(ClaudeAdapter::new()), claude_ref()),
         (Box::new(CodexAdapter::new()), codex_ref()),
-        (Box::new(CopilotAdapter::new()), db_ref(AgentId::Copilot, &env.copilot_db, "cop-0001")),
+        (
+            Box::new(CopilotAdapter::new()),
+            db_ref(AgentId::Copilot, &env.copilot_db, "cop-0001"),
+        ),
         (Box::new(CursorAdapter::new()), cursor_ref()),
-        (Box::new(OpencodeAdapter::new()), db_ref(AgentId::Opencode, &env.opencode_db, "oc-0001")),
+        (
+            Box::new(OpencodeAdapter::new()),
+            db_ref(AgentId::Opencode, &env.opencode_db, "oc-0001"),
+        ),
         (Box::new(KiroAdapter::new()), kiro_ref()),
         (Box::new(GeminiAdapter::new()), gemini_ref()),
         (Box::new(PiAdapter::new()), pi_ref(AgentId::Pi)),
         (Box::new(PiAdapter::omp()), pi_ref(AgentId::Omp)),
         (Box::new(GrokAdapter::new()), grok_ref()),
         (Box::new(KimiAdapter::new()), kimi_ref()),
-        (Box::new(AntigravityAdapter::new()), db_ref(AgentId::Antigravity, &env.antigravity_db, "ag-0001")),
+        (
+            Box::new(AntigravityAdapter::new()),
+            db_ref(AgentId::Antigravity, &env.antigravity_db, "ag-0001"),
+        ),
     ];
     for (adapter, r) in &checks {
         assert_seq_contract(adapter.as_ref(), r);
@@ -867,8 +1075,20 @@ fn merge_quick_meta_default_vs_codex_override() {
 
     // 默认实现(以 Claude 为代表):parsed 为准,quick 只补 source/model/tokens 缺口
     let claude = ClaudeAdapter::new();
-    let parsed = mk_meta(AgentId::ClaudeCode, "claude-code:p", "p", "解析出来的标题", None);
-    let mut quick = mk_meta(AgentId::ClaudeCode, "claude-code:q", "q", "手动改名", Some("state"));
+    let parsed = mk_meta(
+        AgentId::ClaudeCode,
+        "claude-code:p",
+        "p",
+        "解析出来的标题",
+        None,
+    );
+    let mut quick = mk_meta(
+        AgentId::ClaudeCode,
+        "claude-code:q",
+        "q",
+        "手动改名",
+        Some("state"),
+    );
     quick.model = Some("model-q".to_string());
     quick.tokens_used = Some(7);
     let merged = claude.merge_quick_meta(parsed, &quick);
@@ -886,8 +1106,20 @@ fn merge_quick_meta_default_vs_codex_override() {
     // Codex 覆写:state DB 的 title 是用户手动命名,压过解析标题;key/id 以
     // state 的线程 id 为准;source 相反(rollout originator 更精确,quick 只兜底)
     let codex = CodexAdapter::new();
-    let parsed = mk_meta(AgentId::Codex, "codex:file-uuid", "file-uuid", "首条消息推导标题", Some("IDE extension"));
-    let mut quick = mk_meta(AgentId::Codex, "codex:thread-1", "thread-1", "用户手动命名", Some("vscode"));
+    let parsed = mk_meta(
+        AgentId::Codex,
+        "codex:file-uuid",
+        "file-uuid",
+        "首条消息推导标题",
+        Some("IDE extension"),
+    );
+    let mut quick = mk_meta(
+        AgentId::Codex,
+        "codex:thread-1",
+        "thread-1",
+        "用户手动命名",
+        Some("vscode"),
+    );
     quick.model = Some("gpt-5.2".to_string());
     quick.tokens_used = Some(999);
     let merged = codex.merge_quick_meta(parsed, &quick);
@@ -899,15 +1131,33 @@ fn merge_quick_meta_default_vs_codex_override() {
     assert_eq!(merged.tokens_used, Some(999));
 
     // UNTITLED 守卫:quick 的占位标题不得覆盖解析标题,但 key/id 仍取 state
-    let parsed = mk_meta(AgentId::Codex, "codex:file-uuid", "file-uuid", "首条消息推导标题", None);
-    let quick = mk_meta(AgentId::Codex, "codex:thread-1", "thread-1", UNTITLED, Some("vscode"));
+    let parsed = mk_meta(
+        AgentId::Codex,
+        "codex:file-uuid",
+        "file-uuid",
+        "首条消息推导标题",
+        None,
+    );
+    let quick = mk_meta(
+        AgentId::Codex,
+        "codex:thread-1",
+        "thread-1",
+        UNTITLED,
+        Some("vscode"),
+    );
     let merged = codex.merge_quick_meta(parsed, &quick);
     assert_eq!(merged.title, "首条消息推导标题");
     assert_eq!(merged.id, "thread-1");
     assert_eq!(merged.source.as_deref(), Some("vscode")); // parsed 无 source 时兜底
 
     // 空标题同样不覆盖
-    let parsed = mk_meta(AgentId::Codex, "codex:file-uuid", "file-uuid", "首条消息推导标题", None);
+    let parsed = mk_meta(
+        AgentId::Codex,
+        "codex:file-uuid",
+        "file-uuid",
+        "首条消息推导标题",
+        None,
+    );
     let quick = mk_meta(AgentId::Codex, "codex:thread-1", "thread-1", "", None);
     let merged = codex.merge_quick_meta(parsed, &quick);
     assert_eq!(merged.title, "首条消息推导标题");

--- a/crates/wake-core/tests/adapter_contracts.rs
+++ b/crates/wake-core/tests/adapter_contracts.rs
@@ -72,6 +72,14 @@ fn setup() -> &'static TestEnv {
 
         let kimi_dir = home.path().join(".kimi-code");
         fs::create_dir_all(&kimi_dir).expect("mkdir .kimi-code");
+        let codex_dir = home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).expect("mkdir .codex");
+        fs::write(
+            codex_dir.join("session_index.jsonl"),
+            r#"{"id":"22222222-aaaa-bbbb-cccc-000000000002","thread_name":"扫码登录排查","updated_at":1786000000}
+"#,
+        )
+        .expect("write codex session_index");
         fs::write(
             kimi_dir.join("session_index.jsonl"),
             concat!(
@@ -399,8 +407,8 @@ fn codex_parse_contract() {
         .parse_transcript(&r)
         .expect("codex parse_transcript");
 
-    // 标题取首条真实用户消息(environment_context 注入行归 Meta 被跳过)
-    assert_eq!(s.meta.title, "扫码登录报错,帮我查一下 useEffect() 依赖数组");
+    // 标题取 session_index.thread_name(/rename),压过首条用户消息
+    assert_eq!(s.meta.title, "扫码登录排查");
     assert_eq!(s.meta.key, "codex:22222222-aaaa-bbbb-cccc-000000000002");
     assert_eq!(s.meta.project_path, "/Users/tester/Github/wakefx");
     assert_eq!(s.meta.source.as_deref(), Some("CLI")); // originator codex_cli_rs
@@ -722,7 +730,7 @@ fn pi_parse_contract() {
     let s = adapter.parse_session(&r).expect("pi parse_session");
     let t = adapter.parse_transcript(&r).expect("pi parse_transcript");
 
-    assert_eq!(s.meta.title, "Pi 查一下二维码组件的 useEffect() 清理");
+    assert_eq!(s.meta.title, "Pi QR 排查");
     assert_eq!(s.meta.key, "pi:66666666-aaaa-bbbb-cccc-000000000006");
     // cwd 来自 session 首行,不反推有损编码目录名
     assert_eq!(s.meta.project_path, "/Users/tester/Github/wakefx");
@@ -765,7 +773,7 @@ fn pi_parse_contract() {
         .expect("omp parse_session");
     assert_eq!(s2.meta.agent, AgentId::Omp);
     assert_eq!(s2.meta.key, "omp:66666666-aaaa-bbbb-cccc-000000000006");
-    assert_eq!(s2.meta.title, "Pi 查一下二维码组件的 useEffect() 清理");
+    assert_eq!(s2.meta.title, "Pi QR 排查");
 }
 
 #[test]

--- a/crates/wake-core/tests/db_roundtrip.rs
+++ b/crates/wake-core/tests/db_roundtrip.rs
@@ -92,7 +92,9 @@ fn user_data_survives_rebuild() {
     let (_dir, store) = temp_store();
     let m = meta("claude-code:s3", "收藏的会话");
     store.write_session(&m, m.updated_at, &[]).unwrap();
-    store.set_user_data("claude-code:s3", Some(true), Some(true)).unwrap();
+    store
+        .set_user_data("claude-code:s3", Some(true), Some(true))
+        .unwrap();
 
     // 重建索引(sessions/messages 清空重来)后,收藏/置顶必须还在
     store.rebuild_all().unwrap();
@@ -123,13 +125,191 @@ fn list_sessions_filters_and_counts() {
         ascending: false,
         limit: 10,
         offset: 0,
+        roots_only: false,
     };
     let (sessions, total) = store.list_sessions(&all).unwrap();
     assert_eq!(total, 2);
     assert_eq!(sessions[0].key, "claude-code:s4", "默认按 updated 降序");
 
-    let only_codex = SessionFilter { agents: vec![AgentId::Codex], ..all };
+    let only_codex = SessionFilter {
+        agents: vec![AgentId::Codex],
+        ..all
+    };
     let (sessions, total) = store.list_sessions(&only_codex).unwrap();
     assert_eq!(total, 1);
     assert_eq!(sessions[0].key, "codex:s5");
+}
+
+fn grok_meta(key: &str, title: &str, updated: i64) -> SessionMeta {
+    let mut m = meta(key, title);
+    m.agent = AgentId::Grok;
+    m.updated_at = updated;
+    m.created_at = updated;
+    m
+}
+
+#[test]
+fn apply_parent_links_diffs_and_is_idempotent() {
+    let (_dir, store) = temp_store();
+    let p = grok_meta("grok:orch", "调研终端", 100);
+    let c = grok_meta("grok:child", "PR-9", 200);
+    store.write_session(&p, p.updated_at, &[]).unwrap();
+    store.write_session(&c, c.updated_at, &[]).unwrap();
+
+    let changed = store
+        .apply_parent_links(AgentId::Grok, &[("grok:child".into(), "grok:orch".into())])
+        .unwrap();
+    assert!(changed);
+    assert_eq!(
+        store.parent_key_of("grok:child").unwrap().as_deref(),
+        Some("grok:orch")
+    );
+    let changed = store
+        .apply_parent_links(AgentId::Grok, &[("grok:child".into(), "grok:orch".into())])
+        .unwrap();
+    assert!(!changed, "same links must not write");
+
+    let changed = store.apply_parent_links(AgentId::Grok, &[]).unwrap();
+    assert!(changed);
+    assert_eq!(store.parent_key_of("grok:child").unwrap(), None);
+}
+
+#[test]
+fn roots_only_hides_children_unless_parent_missing() {
+    let (_dir, store) = temp_store();
+    let p = grok_meta("grok:orch", "调研终端", 50);
+    let c = grok_meta("grok:child", "PR-9", 200);
+    let orphan = grok_meta("grok:orphan", "无父孩子", 80);
+    store.write_session(&p, p.updated_at, &[]).unwrap();
+    store.write_session(&c, c.updated_at, &[]).unwrap();
+    store
+        .write_session(&orphan, orphan.updated_at, &[])
+        .unwrap();
+    store
+        .apply_parent_links(
+            AgentId::Grok,
+            &[
+                ("grok:child".into(), "grok:orch".into()),
+                ("grok:orphan".into(), "grok:gone".into()),
+            ],
+        )
+        .unwrap();
+
+    let filter = SessionFilter {
+        roots_only: true,
+        sort: SortKey::Updated,
+        ascending: false,
+        limit: 10,
+        ..Default::default()
+    };
+    let (sessions, total) = store.list_sessions(&filter).unwrap();
+    let keys: Vec<_> = sessions.iter().map(|s| s.key.as_str()).collect();
+    assert!(
+        !keys.contains(&"grok:child"),
+        "linked child must not be a root"
+    );
+    assert!(keys.contains(&"grok:orch"));
+    assert!(keys.contains(&"grok:orphan"), "orphan stays visible");
+    assert_eq!(sessions[0].key, "grok:orch", "child activity lifts parent");
+    assert_eq!(total, 2);
+
+    let newer = grok_meta("grok:newer", "PR-15", 300);
+    store.write_session(&newer, newer.updated_at, &[]).unwrap();
+    store
+        .apply_parent_links(
+            AgentId::Grok,
+            &[
+                ("grok:child".into(), "grok:orch".into()),
+                ("grok:newer".into(), "grok:orch".into()),
+                ("grok:orphan".into(), "grok:gone".into()),
+            ],
+        )
+        .unwrap();
+    let kids = store
+        .list_children("grok:orch", SortKey::Updated, false)
+        .unwrap();
+    assert_eq!(
+        kids.iter().map(|s| s.key.as_str()).collect::<Vec<_>>(),
+        vec!["grok:newer", "grok:child"]
+    );
+    let counts = store.child_counts().unwrap();
+    assert_eq!(counts.get("grok:orch").copied(), Some(2));
+
+    // 侧栏 Agents/Projects 只数顶层,不把 2 个子会话叠进 grok 总数
+    let agents = store.agent_counts().unwrap();
+    assert_eq!(
+        agents.get("grok").copied(),
+        Some(2),
+        "orch + orphan, not children"
+    );
+    let projects = store.list_projects().unwrap();
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects[0].session_count, 2);
+    assert_eq!(
+        projects[0].last_active, 300,
+        "child activity still lifts project"
+    );
+}
+
+#[test]
+fn upsert_does_not_clobber_parent_key() {
+    let (_dir, store) = temp_store();
+    let p = grok_meta("grok:orch", "调研终端", 100);
+    let mut c = grok_meta("grok:child", "PR-9", 200);
+    store.write_session(&p, p.updated_at, &[]).unwrap();
+    store.write_session(&c, c.updated_at, &[]).unwrap();
+    store
+        .apply_parent_links(AgentId::Grok, &[("grok:child".into(), "grok:orch".into())])
+        .unwrap();
+
+    c.title = "PR-9 改标题".into();
+    c.updated_at = 400;
+    store.write_session(&c, c.updated_at, &[]).unwrap();
+    assert_eq!(
+        store.parent_key_of("grok:child").unwrap().as_deref(),
+        Some("grok:orch"),
+        "watcher 重解析不得冲掉旁写的父子链"
+    );
+    let got = store.get_session("grok:child").unwrap().unwrap();
+    assert_eq!(got.title, "PR-9 改标题");
+}
+
+#[test]
+fn all_children_includes_archived() {
+    let (_dir, store) = temp_store();
+    let p = grok_meta("grok:orch", "调研终端", 100);
+    let c1 = grok_meta("grok:c1", "A", 200);
+    let mut c2 = grok_meta("grok:c2", "B", 300);
+    c2.archived = true;
+    store.write_session(&p, p.updated_at, &[]).unwrap();
+    store.write_session(&c1, c1.updated_at, &[]).unwrap();
+    store.write_session(&c2, c2.updated_at, &[]).unwrap();
+    store
+        .apply_parent_links(
+            AgentId::Grok,
+            &[
+                ("grok:c1".into(), "grok:orch".into()),
+                ("grok:c2".into(), "grok:orch".into()),
+            ],
+        )
+        .unwrap();
+
+    let kids = store.all_children("grok:orch").unwrap();
+    let mut keys: Vec<_> = kids.iter().map(|s| s.key.as_str()).collect();
+    keys.sort();
+    assert_eq!(keys, vec!["grok:c1", "grok:c2"]);
+    assert_eq!(
+        store
+            .list_children("grok:orch", SortKey::Updated, false)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    store.remove_session("grok:orch", true).unwrap();
+    store.remove_session("grok:c1", true).unwrap();
+    store.remove_session("grok:c2", true).unwrap();
+    assert!(store.get_session("grok:orch").unwrap().is_none());
+    assert!(store.get_session("grok:c1").unwrap().is_none());
+    assert!(store.is_tombstoned(&c1.file_path));
 }

--- a/crates/wake-core/tests/fixtures/claude/projects/-Users-tester-Github-wakefx/11111111-aaaa-bbbb-cccc-000000000001.jsonl
+++ b/crates/wake-core/tests/fixtures/claude/projects/-Users-tester-Github-wakefx/11111111-aaaa-bbbb-cccc-000000000001.jsonl
@@ -7,4 +7,5 @@
 {"parentUuid":"u-0003","isSidechain":false,"cwd":"/Users/tester/Github/wakefx","sessionId":"11111111-aaaa-bbbb-cccc-000000000001","type":"assistant","message":{"id":"msg_02","type":"message","role":"assistant","model":"claude-opus-4-1","content":[{"type":"text","text":"已完成:登录页现在支持二维码扫描,useEffect() 里做了清理。"}]},"uuid":"a-0003","timestamp":"2026-08-01T10:01:00.000Z"}
 {"type":"system","subtype":"compact_boundary","content":"Conversation compacted","isMeta":false,"cwd":"/Users/tester/Github/wakefx","sessionId":"11111111-aaaa-bbbb-cccc-000000000001","uuid":"s-0001","timestamp":"2026-08-01T10:02:00.000Z"}
 {"type":"custom-title","customTitle":"QR login revamp","sessionId":"11111111-aaaa-bbbb-cccc-000000000001"}
+{"type":"custom-title","customTitle":"Wrong session","sessionId":"99999999-aaaa-bbbb-cccc-000000000099"}
 {"type":"wibble-experimental","payload":{"note":"unknown line type, must be counted"}}

--- a/crates/wake-core/tests/fixtures/grok/sessions/wt-ephemeral/aaaaaaaa-aaaa-bbbb-cccc-0000000000aa/summary.json
+++ b/crates/wake-core/tests/fixtures/grok/sessions/wt-ephemeral/aaaaaaaa-aaaa-bbbb-cccc-0000000000aa/summary.json
@@ -1,0 +1,18 @@
+{
+  "info": {
+    "id": "aaaaaaaa-aaaa-bbbb-cccc-0000000000aa",
+    "cwd": "/var/folders/xx/T/grok-501/wt-abcd1234-pr-9"
+  },
+  "session_summary": "Grok worktree review",
+  "created_at": "2026-08-06T12:00:00.000000Z",
+  "updated_at": "2026-08-06T12:10:00.000000Z",
+  "num_messages": 4,
+  "num_chat_messages": 2,
+  "current_model_id": "grok-4.6",
+  "generated_title": "Grok worktree review",
+  "git_root_dir": "/private/var/folders/xx/T/grok-501/wt-abcd1234-pr-9/",
+  "git_remotes": [
+    "/Users/tester/Github/wakefx.origin.git"
+  ],
+  "head_branch": "execute-plan/abcd1234-pr-9-feat-example"
+}

--- a/crates/wake-core/tests/fixtures/grok/sessions/wt-ephemeral/aaaaaaaa-aaaa-bbbb-cccc-0000000000aa/updates.jsonl
+++ b/crates/wake-core/tests/fixtures/grok/sessions/wt-ephemeral/aaaaaaaa-aaaa-bbbb-cccc-0000000000aa/updates.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":1786015200000,"method":"session/update","params":{"sessionId":"aaaaaaaa-aaaa-bbbb-cccc-0000000000aa","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Review the worktree changes"}}}}
+{"timestamp":1786015201000,"method":"session/update","params":{"sessionId":"aaaaaaaa-aaaa-bbbb-cccc-0000000000aa","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Looks good."}}}}

--- a/crates/wake-core/tests/fixtures/grok/sessions/wt-parented/cccccccc-aaaa-bbbb-cccc-0000000000cc/summary.json
+++ b/crates/wake-core/tests/fixtures/grok/sessions/wt-parented/cccccccc-aaaa-bbbb-cccc-0000000000cc/summary.json
@@ -1,0 +1,15 @@
+{
+  "info": {
+    "id": "cccccccc-aaaa-bbbb-cccc-0000000000cc",
+    "cwd": "/var/folders/xx/T/grok-501/wt-abcd1234-pr-9"
+  },
+  "session_summary": "Grok worktree review",
+  "created_at": "2026-08-06T12:00:00.000000Z",
+  "updated_at": "2026-08-06T12:10:00.000000Z",
+  "num_messages": 2,
+  "num_chat_messages": 2,
+  "current_model_id": "grok-4.6",
+  "session_kind": "subagent",
+  "generated_title": "Grok worktree review",
+  "head_branch": "execute-plan/abcd1234-pr-9-feat-example"
+}

--- a/crates/wake-core/tests/fixtures/grok/sessions/wt-parented/cccccccc-aaaa-bbbb-cccc-0000000000cc/updates.jsonl
+++ b/crates/wake-core/tests/fixtures/grok/sessions/wt-parented/cccccccc-aaaa-bbbb-cccc-0000000000cc/updates.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":1786015200000,"method":"session/update","params":{"sessionId":"cccccccc-aaaa-bbbb-cccc-0000000000cc","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Review the worktree changes"}}}}
+{"timestamp":1786015201000,"method":"session/update","params":{"sessionId":"cccccccc-aaaa-bbbb-cccc-0000000000cc","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Looks good."}}}}

--- a/crates/wake-core/tests/fixtures/pi/agent/sessions/--Users-tester-Github-wakefx--/2026-08-06T10-00-00-000Z_66666666-aaaa-bbbb-cccc-000000000006.jsonl
+++ b/crates/wake-core/tests/fixtures/pi/agent/sessions/--Users-tester-Github-wakefx--/2026-08-06T10-00-00-000Z_66666666-aaaa-bbbb-cccc-000000000006.jsonl
@@ -1,4 +1,4 @@
-{"type":"session","version":3,"id":"66666666-aaaa-bbbb-cccc-000000000006","timestamp":"2026-08-06T10:00:00.000Z","cwd":"/Users/tester/Github/wakefx"}
+{"type":"session","version":3,"id":"66666666-aaaa-bbbb-cccc-000000000006","timestamp":"2026-08-06T10:00:00.000Z","cwd":"/Users/tester/Github/wakefx","title":"Pi QR 排查"}
 {"type":"model_change","id":"m1","parentId":null,"timestamp":"2026-08-06T10:00:01.000Z","provider":"openai-codex","modelId":"gpt-5.5"}
 {"type":"thinking_level_change","id":"t1","parentId":"m1","timestamp":"2026-08-06T10:00:01.100Z","thinkingLevel":"medium"}
 {"type":"message","id":"u1","parentId":"t1","timestamp":"2026-08-06T10:00:05.000Z","message":{"role":"user","content":[{"type":"text","text":"Pi 查一下二维码组件的 useEffect() 清理"}],"timestamp":1786010405000}}

--- a/crates/wake/src/main.rs
+++ b/crates/wake/src/main.rs
@@ -1,5 +1,6 @@
 mod assets;
 mod format;
+mod session_list;
 mod theme;
 mod ui;
 mod workbench;

--- a/crates/wake/src/session_list.rs
+++ b/crates/wake/src/session_list.rs
@@ -1,0 +1,292 @@
+//! 中栏会话列表:顶层 + 可展开子代理。
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use gpui::prelude::FluentBuilder as _;
+use gpui::*;
+use gpui_component::list::{ListDelegate, ListEvent, ListItem, ListState};
+use gpui_component::{
+    h_flex, v_flex, ActiveTheme as _, Icon, IndexPath, Sizable as _, StyledExt as _,
+};
+
+use wake_core::db::Store;
+use wake_core::models::*;
+use wake_core::nest::nest_session_rows;
+
+use crate::format::relative_time;
+use crate::theme::STAR_YELLOW;
+use crate::ui::*;
+
+fn icon(path: &'static str) -> Icon {
+    Icon::empty().path(path)
+}
+
+fn badge(name: impl Into<SharedString>, bg: Hsla, fg: Hsla) -> impl IntoElement {
+    div()
+        .min_w_0()
+        .px(px(6.))
+        .py(px(1.))
+        .rounded(px(4.))
+        .bg(bg)
+        .text_color(fg)
+        .font_medium()
+        .child(div().truncate().child(name.into()))
+}
+
+pub struct SessionsDelegate {
+    pub rows: Vec<SessionRow>,
+    pub roots: Vec<SessionMeta>,
+    pub children: HashMap<String, Vec<SessionMeta>>,
+    pub child_counts: HashMap<String, i64>,
+    pub expanded: HashSet<String>,
+    pub sort_key: SortKey,
+    pub ascending: bool,
+    pub tree_mode: bool,
+    pub store: Arc<Store>,
+}
+
+impl SessionsDelegate {
+    pub fn new(store: Arc<Store>) -> Self {
+        Self {
+            rows: Vec::new(),
+            roots: Vec::new(),
+            children: HashMap::new(),
+            child_counts: HashMap::new(),
+            expanded: HashSet::new(),
+            sort_key: SortKey::Updated,
+            ascending: false,
+            tree_mode: true,
+            store,
+        }
+    }
+
+    pub fn rebuild(&mut self) {
+        self.rows = nest_session_rows(
+            self.roots.clone(),
+            &self.child_counts,
+            &self.children,
+            &self.expanded,
+        );
+    }
+
+    /// 顶层刷新:保留仍可见的展开集,对展开节点重拉孩子。
+    pub fn apply_roots(
+        &mut self,
+        roots: Vec<SessionMeta>,
+        child_counts: HashMap<String, i64>,
+        tree_mode: bool,
+        sort_key: SortKey,
+        ascending: bool,
+    ) {
+        self.roots = roots;
+        self.sort_key = sort_key;
+        self.ascending = ascending;
+        self.tree_mode = tree_mode;
+        if tree_mode {
+            self.child_counts = child_counts;
+            let root_keys: HashSet<String> = self.roots.iter().map(|s| s.key.clone()).collect();
+            self.expanded.retain(|k| root_keys.contains(k));
+            self.children.retain(|k, _| self.expanded.contains(k));
+            let open: Vec<String> = self.expanded.iter().cloned().collect();
+            for k in open {
+                if let Ok(kids) = self.store.list_children(&k, self.sort_key, self.ascending) {
+                    self.children.insert(k, kids);
+                }
+            }
+        } else {
+            self.child_counts.clear();
+            self.children.clear();
+            self.expanded.clear();
+        }
+        self.rebuild();
+    }
+
+    pub fn toggle(&mut self, key: &str) {
+        if !self.expanded.remove(key) {
+            self.expanded.insert(key.to_string());
+            if let Ok(kids) = self.store.list_children(key, self.sort_key, self.ascending) {
+                self.children.insert(key.to_string(), kids);
+            }
+        } else {
+            self.children.remove(key);
+        }
+        self.rebuild();
+    }
+
+    pub fn ensure_expanded(&mut self, parent_key: &str) {
+        if self.expanded.insert(parent_key.to_string()) {
+            if let Ok(kids) = self
+                .store
+                .list_children(parent_key, self.sort_key, self.ascending)
+            {
+                self.children.insert(parent_key.to_string(), kids);
+            }
+            self.rebuild();
+        }
+    }
+}
+
+impl ListDelegate for SessionsDelegate {
+    type Item = ListItem;
+
+    fn items_count(&self, _section: usize, _cx: &App) -> usize {
+        self.rows.len()
+    }
+
+    fn render_item(
+        &mut self,
+        ix: IndexPath,
+        _window: &mut Window,
+        cx: &mut Context<ListState<Self>>,
+    ) -> Option<Self::Item> {
+        let s = self.rows.get(ix.row)?;
+        let theme = cx.theme();
+        let key = s.meta.key.clone();
+        let toggle_key = key.clone();
+        let open_key = key.clone();
+        let child_count = s.child_count;
+        let expanded = s.expanded;
+        let depth = s.depth;
+        let title = s.meta.title.clone();
+        let pinned = s.meta.pinned;
+        let favorite = s.meta.favorite;
+        let agent_icon = s.meta.agent.brand_icon(theme.mode.is_dark());
+        let project_name = s.meta.project_name.clone();
+        let updated_at = s.meta.updated_at;
+        let show_chevron = self.tree_mode && child_count > 0;
+
+        Some(
+            // 行身份用会话 key,不能用 row:展开后子会话占用原下一行的下标,
+            // GPUI 会复用旧元素的 click 状态,第一次点第一条孩子对不上 Confirm。
+            ListItem::new(SharedString::from(key.clone()))
+                .rounded(theme.radius)
+                .mx(SPACE_SM)
+                .child(
+                    v_flex()
+                        .id(SharedString::from(format!("row:{key}")))
+                        .w_full()
+                        .px(SPACE_XS)
+                        .py(SPACE_SM)
+                        .gap(SPACE_XS)
+                        .when(depth > 0, |el| el.pl(px(16.)))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, window, cx| {
+                                // 按 key 定位,不靠 List 外层 on_click 的捕获下标。
+                                // mouse_down 立刻 Confirm,避开展开后 hitbox 位移吞掉 click。
+                                cx.stop_propagation();
+                                let Some(row) = this
+                                    .delegate()
+                                    .rows
+                                    .iter()
+                                    .position(|r| r.meta.key == open_key)
+                                else {
+                                    return;
+                                };
+                                let already = this.selected_index().is_some_and(|ix| ix.row == row);
+                                let grouped = this.delegate().tree_mode
+                                    && this
+                                        .delegate()
+                                        .rows
+                                        .get(row)
+                                        .is_some_and(|r| r.child_count > 0);
+                                // 已选中的分组行再点一次:展开/收起,不重复打开详情
+                                if already && grouped {
+                                    this.delegate_mut().toggle(&open_key);
+                                    cx.notify();
+                                    return;
+                                }
+                                let ix = IndexPath::new(row);
+                                this.focus(window, cx);
+                                this.set_selected_index(Some(ix), window, cx);
+                                cx.emit(ListEvent::Confirm(ix));
+                                cx.notify();
+                            }),
+                        )
+                        .child(
+                            h_flex()
+                                .gap_1p5()
+                                .when(show_chevron, |this| {
+                                    this.child(
+                                        div()
+                                            .id(SharedString::from(format!("exp:{toggle_key}")))
+                                            .size(px(16.))
+                                            .flex_shrink_0()
+                                            .rounded(px(4.))
+                                            .cursor_pointer()
+                                            .flex()
+                                            .items_center()
+                                            .justify_center()
+                                            .hover(|s| s.bg(theme.muted))
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(move |this, _, _, cx| {
+                                                    cx.stop_propagation();
+                                                    this.delegate_mut().toggle(&toggle_key);
+                                                    cx.notify();
+                                                }),
+                                            )
+                                            .child(
+                                                icon("icons/chevron-right.svg")
+                                                    .with_size(px(13.))
+                                                    .text_color(theme.muted_foreground)
+                                                    .when(expanded, |ic| {
+                                                        ic.rotate(gpui::Radians(
+                                                            std::f32::consts::FRAC_PI_2,
+                                                        ))
+                                                    }),
+                                            ),
+                                    )
+                                })
+                                .child(
+                                    div()
+                                        .flex_1()
+                                        .min_w_0()
+                                        .text_size(FONT_BODY)
+                                        .font_medium()
+                                        .text_color(theme.foreground)
+                                        .truncate()
+                                        .child(title),
+                                )
+                                .when(pinned, |this| {
+                                    this.child(
+                                        icon("icons/pin-filled.svg")
+                                            .with_size(px(11.))
+                                            .text_color(theme.primary),
+                                    )
+                                })
+                                .when(favorite, |this| {
+                                    this.child(
+                                        icon("icons/star-filled.svg")
+                                            .with_size(px(11.))
+                                            .text_color(rgb(STAR_YELLOW)),
+                                    )
+                                }),
+                        )
+                        .child(
+                            h_flex()
+                                .gap_1p5()
+                                .text_size(FONT_LABEL)
+                                .text_color(theme.muted_foreground)
+                                .child(img(agent_icon).size(px(15.)).flex_shrink_0())
+                                .child(badge(project_name, theme.muted, theme.muted_foreground))
+                                .when(show_chevron, |this| {
+                                    this.child(
+                                        div().flex_shrink_0().child(format!("{child_count}")),
+                                    )
+                                })
+                                .child(div().flex_1())
+                                .child(div().flex_shrink_0().child(relative_time(updated_at))),
+                        ),
+                ),
+        )
+    }
+
+    fn set_selected_index(
+        &mut self,
+        _ix: Option<IndexPath>,
+        _window: &mut Window,
+        _cx: &mut Context<ListState<Self>>,
+    ) {
+    }
+}

--- a/crates/wake/src/workbench.rs
+++ b/crates/wake/src/workbench.rs
@@ -33,21 +33,26 @@ use gpui_component::scroll::ScrollableElement as _;
 use gpui_component::spinner::Spinner;
 use gpui_component::text::{TextView, TextViewStyle};
 use gpui_component::{
-    h_flex, v_flex, ActiveTheme as _, Icon, IndexPath, Root, Sizable as _,
-    StyledExt as _, TitleBar, WindowExt as _,
+    h_flex, v_flex, ActiveTheme as _, Icon, IndexPath, Root, Sizable as _, StyledExt as _,
+    TitleBar, WindowExt as _,
 };
 
 use wake_core::adapters::{create_adapters, AgentAdapter};
 use wake_core::db::Store;
 use wake_core::models::*;
 use wake_core::scanner::{run_scan, ScanEvents, ScanProgress};
+
+use crate::session_list::SessionsDelegate;
 use wake_core::services::{exporter, terminal};
 use wake_core::watcher::{start_watcher, SessionWatcher};
 
-use crate::ui::*;
 use crate::format::{abs_date, display_file_path, fmt_tokens, one_line, relative_time};
+use crate::ui::*;
 
-actions!(wake, [ToggleSearch, RefreshSessions, PaletteUp, PaletteDown]);
+actions!(
+    wake,
+    [ToggleSearch, RefreshSessions, PaletteUp, PaletteDown]
+);
 
 pub const KEY_CONTEXT: &str = "Workbench";
 /// ⌘K 面板容器的 key context(main.rs 的 ↑↓ 绑定与 dialog 元素共用)
@@ -87,87 +92,6 @@ impl ScanEvents for ChannelEvents {
     }
     fn on_sessions_changed(&self) {
         let _ = self.0.unbounded_send(BgEvent::Changed);
-    }
-}
-
-// ---------------- 会话列表 delegate ----------------
-
-pub struct SessionsDelegate {
-    pub sessions: Vec<SessionMeta>,
-}
-
-impl ListDelegate for SessionsDelegate {
-    type Item = ListItem;
-
-    fn items_count(&self, _section: usize, _cx: &App) -> usize {
-        self.sessions.len()
-    }
-
-    fn render_item(
-        &mut self,
-        ix: IndexPath,
-        _window: &mut Window,
-        cx: &mut Context<ListState<Self>>,
-    ) -> Option<Self::Item> {
-        let s = self.sessions.get(ix.row)?;
-        let theme = cx.theme();
-
-        Some(
-            ListItem::new(ix.row).rounded(theme.radius).mx(SPACE_SM).child(
-                v_flex()
-                    .w_full()
-                    .px(SPACE_XS)
-                    .py(SPACE_SM)
-                    .gap(SPACE_XS)
-                    .child(
-                        h_flex()
-                            .gap_1p5()
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .min_w_0()
-                                    .text_size(FONT_BODY)
-                                    .font_medium()
-                                    .text_color(theme.foreground)
-                                    .truncate()
-                                    .child(s.title.clone()),
-                            )
-                            .when(s.pinned, |this| {
-                                this.child(
-                                    icon("icons/pin-filled.svg")
-                                        .with_size(px(11.))
-                                        .text_color(theme.primary),
-                                )
-                            })
-                            .when(s.favorite, |this| {
-                                this.child(
-                                    icon("icons/star-filled.svg")
-                                        .with_size(px(11.))
-                                        .text_color(rgb(crate::theme::STAR_YELLOW)),
-                                )
-                            }),
-                    )
-                    .child(
-                        h_flex()
-                            .gap_1p5()
-                            .text_size(FONT_LABEL)
-                            .text_color(theme.muted_foreground)
-                            .child(img(s.agent.brand_icon(theme.mode.is_dark())).size(px(15.)).flex_shrink_0())
-                            .child(badge(s.project_name.clone(), theme.muted, theme.muted_foreground))
-                            .child(div().flex_1())
-                            .child(div().flex_shrink_0().child(relative_time(s.updated_at))),
-                    ),
-            ),
-        )
-    }
-
-    // 点击/回车走 ListEvent::Confirm(ix),无需自存选中态
-    fn set_selected_index(
-        &mut self,
-        _ix: Option<IndexPath>,
-        _window: &mut Window,
-        _cx: &mut Context<ListState<Self>>,
-    ) {
     }
 }
 
@@ -213,7 +137,11 @@ impl ListDelegate for SearchDelegate {
                         h_flex()
                             .gap_2()
                             .text_size(FONT_CAPTION)
-                            .child(img(h.session.agent.brand_icon(theme.mode.is_dark())).size(px(15.)).flex_shrink_0())
+                            .child(
+                                img(h.session.agent.brand_icon(theme.mode.is_dark()))
+                                    .size(px(15.))
+                                    .flex_shrink_0(),
+                            )
                             .child(
                                 div()
                                     .min_w_0()
@@ -267,7 +195,9 @@ impl ListDelegate for SearchDelegate {
             if q.trim().is_empty() {
                 (Vec::new(), false)
             } else {
-                store.search(&q, &[], None, 60).unwrap_or((Vec::new(), false))
+                store
+                    .search(&q, &[], None, 60)
+                    .unwrap_or((Vec::new(), false))
             }
         });
         cx.spawn_in(window, async move |this, cx| {
@@ -430,14 +360,7 @@ impl Workbench {
         let adapters: Arc<Vec<Box<dyn AgentAdapter>>> = Arc::new(create_adapters());
 
         let list_state = cx.new(|cx| {
-            ListState::new(
-                SessionsDelegate {
-                    sessions: Vec::new(),
-                },
-                window,
-                cx,
-            )
-            .searchable(false)
+            ListState::new(SessionsDelegate::new(store.clone()), window, cx).searchable(false)
         });
         let palette_list = cx.new(|cx| {
             ListState::new(
@@ -527,7 +450,10 @@ impl Workbench {
 
         // 终端应用图标后台提取(首次数百 ms,之后命中缓存)
         let icons_task = cx.background_spawn(async {
-            let dir = dirs::data_dir().unwrap_or_default().join("wake").join("app-icons");
+            let dir = dirs::data_dir()
+                .unwrap_or_default()
+                .join("wake")
+                .join("app-icons");
             terminal::ensure_app_icons(&dir)
         });
         cx.spawn_in(window, async move |this, cx| {
@@ -555,6 +481,7 @@ impl Workbench {
             ascending: self.sort_ascending,
             limit: 500,
             offset: 0,
+            roots_only: !self.favorite_only,
         }
     }
 
@@ -562,8 +489,22 @@ impl Workbench {
         let filter = self.current_filter();
         if let Ok((sessions, total)) = self.store.list_sessions(&filter) {
             self.total_sessions = total;
+            let tree_mode = filter.roots_only;
+            let child_counts = if tree_mode {
+                self.store.child_counts().unwrap_or_default()
+            } else {
+                Default::default()
+            };
+            let sort_key = self.sort_key;
+            let ascending = self.sort_ascending;
             self.list_state.update(cx, |state, cx| {
-                state.delegate_mut().sessions = sessions;
+                state.delegate_mut().apply_roots(
+                    sessions,
+                    child_counts,
+                    tree_mode,
+                    sort_key,
+                    ascending,
+                );
                 cx.notify();
             });
         }
@@ -623,16 +564,13 @@ impl Workbench {
                     v_flex()
                         .gap(SPACE_LG)
                         .child(
-                            h_flex()
-                                .gap_2()
-                                .child(Spinner::new().small())
-                                .child(
-                                    div()
-                                        .text_size(FONT_HEADING)
-                                        .font_semibold()
-                                        .text_color(theme.foreground)
-                                        .child("Refreshing sessions"),
-                                ),
+                            h_flex().gap_2().child(Spinner::new().small()).child(
+                                div()
+                                    .text_size(FONT_HEADING)
+                                    .font_semibold()
+                                    .text_color(theme.foreground)
+                                    .child("Refreshing sessions"),
+                            ),
                         )
                         .child(Progress::new().value(pct))
                         .child(
@@ -685,9 +623,9 @@ impl Workbench {
         let key = list
             .read(cx)
             .delegate()
-            .sessions
+            .rows
             .get(ix.row)
-            .map(|s| s.key.clone());
+            .map(|s| s.meta.key.clone());
         if let Some(key) = key {
             self.open_detail(&key, None, window, cx);
         }
@@ -710,12 +648,7 @@ impl Workbench {
         }
     }
 
-    pub fn toggle_search(
-        &mut self,
-        _: &ToggleSearch,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    pub fn toggle_search(&mut self, _: &ToggleSearch, window: &mut Window, cx: &mut Context<Self>) {
         if self.refreshing {
             return;
         }
@@ -743,12 +676,18 @@ impl Workbench {
                         // ↑↓ 在 Input 内不被消费,冒泡到这里走 main.rs 的
                         // PALETTE_CONTEXT 键位(Input 拆出 List 后原生 List 绑定够不着)
                         .key_context(PALETTE_CONTEXT)
-                        .on_action(window.listener_for(&this, |wb: &mut Self, _: &PaletteUp, window, cx| {
-                            wb.palette_move(-1, window, cx)
-                        }))
-                        .on_action(window.listener_for(&this, |wb: &mut Self, _: &PaletteDown, window, cx| {
-                            wb.palette_move(1, window, cx)
-                        }))
+                        .on_action(window.listener_for(
+                            &this,
+                            |wb: &mut Self, _: &PaletteUp, window, cx| {
+                                wb.palette_move(-1, window, cx)
+                            },
+                        ))
+                        .on_action(window.listener_for(
+                            &this,
+                            |wb: &mut Self, _: &PaletteDown, window, cx| {
+                                wb.palette_move(1, window, cx)
+                            },
+                        ))
                         // 定高 + 列表 flex_1:输入行/footer 尺寸变化时列表自适应,
                         // 不用手工重算列表高度
                         .h(PALETTE_HEIGHT)
@@ -882,11 +821,7 @@ impl Workbench {
                     this.update_in(cx, |this, window, cx| {
                         this.palette_list.update(cx, |state, cx| {
                             let has_hits = !state.delegate().hits.is_empty();
-                            state.set_selected_index(
-                                has_hits.then(IndexPath::default),
-                                window,
-                                cx,
-                            );
+                            state.set_selected_index(has_hits.then(IndexPath::default), window, cx);
                             // scroll_to_item 自带 notify,列表随之重绘
                             state.scroll_to_item(
                                 IndexPath::default(),
@@ -935,10 +870,7 @@ impl Workbench {
             if n == 0 {
                 return;
             }
-            let cur = state
-                .selected_index()
-                .map(|ix| ix.row as i64)
-                .unwrap_or(-1);
+            let cur = state.selected_index().map(|ix| ix.row as i64).unwrap_or(-1);
             let next = (cur + delta).clamp(0, n - 1) as usize;
             state.set_selected_index(Some(IndexPath::new(next)), window, cx);
             // scroll_to_selected_item 内部 notify,选中高亮随之重绘
@@ -998,8 +930,11 @@ impl Workbench {
                 if let Some(detail) = &mut this.detail {
                     match result {
                         Some((key, messages)) if key == detail.meta.key => {
-                            detail.msg_list =
-                                gpui::ListState::new(messages.len(), gpui::ListAlignment::Bottom, px(512.));
+                            detail.msg_list = gpui::ListState::new(
+                                messages.len(),
+                                gpui::ListAlignment::Bottom,
+                                px(512.),
+                            );
                             // 搜索跳转:seq → 可见消息下标,滚到视口顶。
                             // FTS 命中的行可能被详情过滤(如空文本),用 >= 落到
                             // 其后最近一条;找不到(尾部被滤)则保持默认落底。
@@ -1040,13 +975,18 @@ impl Workbench {
     /// 命中可能不在列表里),中栏定位选中该会话并滚到可见
     fn sync_list_selection(&mut self, key: &str, window: &mut Window, cx: &mut Context<Self>) {
         self.show_all_sessions(window, cx);
+        if let Ok(Some(pk)) = self.store.parent_key_of(key) {
+            self.list_state.update(cx, |state, _| {
+                state.delegate_mut().ensure_expanded(&pk);
+            });
+        }
         let row = self
             .list_state
             .read(cx)
             .delegate()
-            .sessions
+            .rows
             .iter()
-            .position(|s| s.key == key);
+            .position(|s| s.meta.key == key);
         if let Some(row) = row {
             self.list_state.update(cx, |state, cx| {
                 state.set_selected_index(Some(IndexPath::new(row)), window, cx);
@@ -1081,7 +1021,12 @@ impl Workbench {
         .detach();
     }
 
-    fn do_resume(&mut self, term: terminal::TerminalApp, window: &mut Window, cx: &mut Context<Self>) {
+    fn do_resume(
+        &mut self,
+        term: terminal::TerminalApp,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let Some(detail) = &self.detail else { return };
         self.preferred_terminal = Some(term);
         cx.notify(); // split 按钮左段立即切到本次选择
@@ -1148,30 +1093,45 @@ impl Workbench {
     /// 否则界面在授权框弹出的整段时间里完全冻结。
     fn do_delete(
         &mut self,
-        key: String,
+        keys: Vec<String>,
         targets: Vec<String>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let store = self.store.clone();
-        let trash_key = key.clone();
+        let n = keys.len();
+        let trash_keys = keys.clone();
         let task = cx.background_spawn(async move {
-            terminal::trash_paths(&targets).and_then(|()| store.remove_session(&trash_key, true))
+            terminal::trash_paths(&targets)?;
+            for k in &trash_keys {
+                store.remove_session(k, true)?;
+            }
+            anyhow::Ok(())
         });
         cx.spawn_in(window, async move |this, cx| {
             let result = task.await;
             this.update_in(cx, |this, window, cx| match result {
                 Ok(()) => {
-                    // 等待期间用户可能已翻到别的会话,只在仍停在被删那条时才清空
-                    if this.detail.as_ref().is_some_and(|d| d.meta.key == key) {
+                    // 等待期间用户可能已翻到别的会话,只在仍停在被删树内时才清空
+                    if this
+                        .detail
+                        .as_ref()
+                        .is_some_and(|d| keys.iter().any(|k| k == &d.meta.key))
+                    {
                         this.detail = None;
                     }
-                    window.push_notification(Notification::success("Session moved to Trash"), cx);
+                    let msg = if n > 1 {
+                        format!("{n} sessions moved to Trash")
+                    } else {
+                        "Session moved to Trash".into()
+                    };
+                    window.push_notification(Notification::success(msg), cx);
                     // 立刻把它从列表摘掉,不等 watcher 那 800ms 去抖
                     this.refresh(window, cx);
                 }
-                Err(e) => window
-                    .push_notification(Notification::error(format!("Delete failed: {e}")), cx),
+                Err(e) => {
+                    window.push_notification(Notification::error(format!("Delete failed: {e}")), cx)
+                }
             })
             .ok();
         })
@@ -1181,27 +1141,53 @@ impl Workbench {
     fn confirm_delete(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(detail) = &self.detail else { return };
         let meta = detail.meta.clone();
+        let children = self.store.all_children(&meta.key).unwrap_or_default();
+        let n_children = children.len();
         // 会话归属哪些磁盘路径(主文件/边车目录)是 adapter 的布局知识
-        let targets = self
-            .adapters
-            .iter()
-            .find(|a| a.agent() == meta.agent)
-            .map(|a| a.session_paths(&meta))
-            .unwrap_or_else(|| vec![meta.file_path.clone()]);
+        let adapter = self.adapters.iter().find(|a| a.agent() == meta.agent);
+        let mut targets = Vec::new();
+        let mut keys = Vec::with_capacity(1 + n_children);
+        let mut push = |m: &SessionMeta| {
+            keys.push(m.key.clone());
+            let paths = adapter
+                .map(|a| a.session_paths(m))
+                .unwrap_or_else(|| vec![m.file_path.clone()]);
+            for p in paths {
+                if !targets.contains(&p) {
+                    targets.push(p);
+                }
+            }
+        };
+        push(&meta);
+        for c in &children {
+            push(c);
+        }
         let entity = cx.entity();
         window.open_dialog(cx, move |dialog, _window, cx| {
-            let meta = meta.clone();
+            let keys = keys.clone();
             let targets = targets.clone();
             let entity = entity.clone();
             let theme = cx.theme();
+            let title = if n_children > 0 {
+                "Delete this session and nested sessions?"
+            } else {
+                "Delete this session?"
+            };
+            let lead = if n_children > 0 {
+                format!(
+                    "This session and {n_children} nested sessions will be moved to Trash. You can restore them anytime:"
+                )
+            } else {
+                "The session file will be moved to Trash. You can restore it anytime:".into()
+            };
             dialog
-                .title(div().font_semibold().child("Delete this session?"))
+                .title(div().font_semibold().child(title))
                 .w(px(440.))
                 .child(
                     v_flex()
                         .gap_2()
                         .text_size(FONT_BODY)
-                        .child("The session file will be moved to Trash. You can restore it anytime:")
+                        .child(lead)
                         .child(
                             div()
                                 .px_2()
@@ -1223,7 +1209,7 @@ impl Workbench {
                 )
                 .on_ok(move |_, window, cx| {
                     entity.update(cx, |this, cx| {
-                        this.do_delete(meta.key.clone(), targets.clone(), window, cx);
+                        this.do_delete(keys.clone(), targets.clone(), window, cx);
                     });
                     true
                 })
@@ -1253,9 +1239,8 @@ impl Workbench {
 
     fn render_sidebar(&self, cx: &Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
-        let all_active = self.selected_agent.is_none()
-            && self.selected_project.is_none()
-            && !self.favorite_only;
+        let all_active =
+            self.selected_agent.is_none() && self.selected_project.is_none() && !self.favorite_only;
         // 常态沉默,仅刷新中/监听失效时出现;None 时状态栏整行不渲染。
         // 文案在此按 scan 现算,不另存字段——存下来就会有第二个写入点要维护
         let note = if self.scan.scanning {
@@ -1264,7 +1249,10 @@ impl Workbench {
                 total => format!("Refreshing {}/{}", self.scan.done, total),
             })
         } else {
-            self.scan.error.as_ref().map(|e| format!("Refresh failed: {e}"))
+            self.scan
+                .error
+                .as_ref()
+                .map(|e| format!("Refresh failed: {e}"))
         };
         let status: Option<AnyElement> = if let Some(note) = note {
             Some(
@@ -1272,7 +1260,11 @@ impl Workbench {
                     .w_full()
                     .gap(SPACE_SM)
                     .text_color(theme.muted_foreground)
-                    .child(icon("icons/refresh-cw.svg").with_size(px(12.)).flex_shrink_0())
+                    .child(
+                        icon("icons/refresh-cw.svg")
+                            .with_size(px(12.))
+                            .flex_shrink_0(),
+                    )
                     .child(div().min_w_0().truncate().child(note))
                     .into_any_element(),
             )
@@ -1282,7 +1274,13 @@ impl Workbench {
                     .w_full()
                     .gap(SPACE_SM)
                     .text_color(theme.muted_foreground)
-                    .child(div().size(px(7.)).rounded_full().flex_shrink_0().bg(theme.warning))
+                    .child(
+                        div()
+                            .size(px(7.))
+                            .rounded_full()
+                            .flex_shrink_0()
+                            .bg(theme.warning),
+                    )
                     .child(div().min_w_0().truncate().child("Live updates off"))
                     .into_any_element(),
             )
@@ -1341,22 +1339,11 @@ impl Workbench {
                                 .on_click(cx.listener(|this, _, window, cx| {
                                     this.toggle_search(&ToggleSearch, window, cx)
                                 }))
-                                .child(
-                                    icon("icons/search.svg")
-                                        .with_size(px(13.))
-                                        .flex_shrink_0(),
-                                )
+                                .child(icon("icons/search.svg").with_size(px(13.)).flex_shrink_0())
                                 // flex_1 + min_w_0 + truncate:空间不足时压这里,
                                 // 绝不把右侧刷新按钮挤出侧栏
-                                .child(
-                                    div().flex_1().min_w_0().truncate().child("Search sessions"),
-                                )
-                                .child(
-                                    div()
-                                        .flex_shrink_0()
-                                        .text_size(FONT_LABEL)
-                                        .child("⌘K"),
-                                ),
+                                .child(div().flex_1().min_w_0().truncate().child("Search sessions"))
+                                .child(div().flex_shrink_0().text_size(FONT_LABEL).child("⌘K")),
                         )
                         .child({
                             let busy = self.scan.scanning;
@@ -1373,8 +1360,7 @@ impl Workbench {
                                 .when(!busy, |el| {
                                     el.cursor_pointer()
                                         .hover(|s| {
-                                            s.bg(theme.secondary_hover)
-                                                .text_color(theme.foreground)
+                                            s.bg(theme.secondary_hover).text_color(theme.foreground)
                                         })
                                         .active(|s| {
                                             s.bg(theme.secondary_active)
@@ -1416,7 +1402,11 @@ impl Workbench {
                         "fav",
                         RowLead::Icon(icon("icons/star.svg")),
                         "Starred",
-                        if self.starred_count > 0 { Some(self.starred_count) } else { None },
+                        if self.starred_count > 0 {
+                            Some(self.starred_count)
+                        } else {
+                            None
+                        },
                         self.favorite_only,
                         RowLevel::Primary,
                         cx.listener(|this, _, window, cx| {
@@ -1527,7 +1517,7 @@ impl Workbench {
 
     fn render_session_list(&self, cx: &Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
-        let shown = self.list_state.read(cx).delegate().sessions.len();
+        let shown = self.list_state.read(cx).delegate().rows.len();
         let sort_key = self.sort_key;
         let sort_ascending = self.sort_ascending;
         let sort_entity = cx.entity();
@@ -1547,14 +1537,14 @@ impl Workbench {
             .dropdown_menu(move |menu, _, _| {
                 let mk_key = |label: &'static str, key: SortKey| {
                     let entity = sort_entity.clone();
-                    PopupMenuItem::new(label)
-                        .checked(sort_key == key)
-                        .on_click(move |_, window, cx| {
+                    PopupMenuItem::new(label).checked(sort_key == key).on_click(
+                        move |_, window, cx| {
                             entity.update(cx, |this, cx| {
                                 this.sort_key = key;
                                 this.refresh(window, cx);
                             });
-                        })
+                        },
+                    )
                 };
                 let mk_dir = |label: &'static str, ascending: bool| {
                     let entity = sort_entity.clone();
@@ -1616,7 +1606,10 @@ impl Workbench {
                     ))
                     .into_any_element()
             } else {
-                List::new(&self.list_state).flex_1().min_h_0().into_any_element()
+                List::new(&self.list_state)
+                    .flex_1()
+                    .min_h_0()
+                    .into_any_element()
             })
     }
 
@@ -1624,7 +1617,12 @@ impl Workbench {
 
     /// gpui::list 的行渲染。在布局阶段经 entity.update 调用(render 已返回,
     /// lease 已释放,无 double-lease 风险——与 dialog builder 的时机不同)。
-    fn render_msg_row(&mut self, ix: usize, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+    fn render_msg_row(
+        &mut self,
+        ix: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
         let theme = cx.theme();
         let dark = theme.mode.is_dark();
         let muted_fg = theme.muted_foreground;
@@ -2434,7 +2432,11 @@ fn sidebar_row(
         .flex_shrink_0()
         // 分组项整行右移一档表达从属:行首因此落在轴右侧 SUB_INDENT 处,
         // 压轴的是主导航与组头,不是这里
-        .pl(if sub { LEAD_INSET + SUB_INDENT } else { LEAD_INSET })
+        .pl(if sub {
+            LEAD_INSET + SUB_INDENT
+        } else {
+            LEAD_INSET
+        })
         .pr(SIDEBAR_EDGE)
         .rounded(theme.radius)
         .cursor_pointer()
@@ -2475,9 +2477,7 @@ fn sidebar_row(
                                 .into_any_element(),
                             // 品牌图不着色:img 走 AssetSource 取内嵌 PNG,原色渲染
                             // (侧栏单色化试过,用户否决——保持彩色)
-                            RowLead::Brand(path) => {
-                                img(path).size(LEAD_BOX).into_any_element()
-                            }
+                            RowLead::Brand(path) => img(path).size(LEAD_BOX).into_any_element(),
                         }),
                 )
                 .child(
@@ -2512,7 +2512,9 @@ fn tool_btn(
     on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
 ) -> Button {
     let ic = if highlighted {
-        icon(filled_icon_path).with_size(px(16.)).text_color(active_color)
+        icon(filled_icon_path)
+            .with_size(px(16.))
+            .text_color(active_color)
     } else {
         icon(icon_path).with_size(px(16.))
     };


### PR DESCRIPTION
## Summary

Grok Build `execute-plan` / worktree sessions now nest under the parent session in the list (e.g. 调研终端), instead of showing up as a flat pile of `wt-…-pr-N` rows.

- Parent links come from the orchestrator session's `subagents/*/meta.json` (`parent_session_id` / `child_session_id`).
- `parent_key` is a DB-only column. `SessionMeta` and the other 11 adapters are unchanged; `upsert` does not overwrite existing links.
- Worktree / git-remote / ephemeral heuristics stay as a **no-parent fallback**, so unparented worktrees still group under the source repo.
- Sidebar All Sessions / Agents / Projects counts list **top-level rows only**. Nested children show as the number on the parent row. Starred and ⌘K stay flat.
- Deleting a parent also moves nested sessions to Trash (tombstone included).
- Click the chevron to expand, or click a selected grouped row again to expand/collapse.
- Cursor project slugs restore `_` in directory names (`app_av4` no longer becomes `app/av4`).

Version bump to **0.3.0** (new list interaction, not a patch on 0.2.1).

## Limitations

- Watcher only reacts to `updates.jsonl`. A `meta.json`-only change needs the next Grok file event or ⌘R.
- Nesting is one level: a subagent of a subagent hangs off the root parent.

## Test plan

- [x] `cargo test -p wake-core`
- [x] `cargo build -p wake`
- [x] Open a Grok parent with subagents → chevron + count, expand shows children
- [x] First click on the first child after expand opens that session
- [ ] Click a selected grouped parent again to expand/collapse
- [ ] Delete the parent → children go to Trash and stay gone after rescan
- [ ] Sidebar Grok / All Sessions counts match visible top-level rows (children not stacked)
- [ ] ⌘R picks up a newly spawned subagent without restarting the app
- [ ] Cursor session whose cwd is `…/app_av4` shows `app_av4`, not `av4`