### PR TITLE
UI 整体升级：会话列表、会话详情头部元信息排版、对话正文内容渲染样式优化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- Update: the transcript now reads like a document — assistant replies at 14.5px with 1.92 line height in a 612px column (about 42 CJK characters per line), roomier spacing between blocks, clearer heading levels, and code blocks with a language label and a copy button
+- Update: your own messages keep their bubble; role is conveyed by shape rather than a label
+- Update: thinking can be expanded instead of being cut to a single line forever
+- Update: tool calls are collapsible cards that show the arguments while collapsed, and expand to both the input and the output — successful calls included, not just failures
+- Update: session detail header is two lines instead of six; the project path, exact timestamps and the session file path move into tooltips and the overflow menu
+- Update: the session list groups by Today / Yesterday / Earlier, shows a total count, and puts the message count on every row
+- Fix: long session titles are truncated with an ellipsis instead of being cut mid-character
+- Fix: while the first scan is running the list says it is indexing, instead of claiming there are no matching sessions
+- Fix: when the list is capped, it says how many of the total are shown instead of silently truncating
+- Fix: a session that fails to parse shows why, with a button to reveal the file, instead of an empty reading pane
+- Fix: `HEAD` is no longer shown as a git branch name
+- Fix: code blocks now switch colours together with the appearance — they used to keep the previous theme's palette, and even then only caught up after a delay
+- Update: the default window is sized from your screen (78% × 82%, capped at 1400 × 900) instead of a fixed 1180 × 760
+
 ## [0.3.0] — 2026-08-27
 
 - New: Insights page — a new sidebar entry showing your coding agent activity at a glance: sessions, tokens, prompts, agents, projects, and active days

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6812,6 +6812,7 @@ dependencies = [
  "futures",
  "gpui",
  "gpui-component",
+ "objc",
  "semver",
  "serde",
  "serde_json",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,7 +35,7 @@ Wake 的目标不是展示技术感，而是让用户在几秒内重新找到并
 
 | 项目 | 规格 |
 |---|---|
-| 默认窗口 | 1180 × 760，居中(14" 屏约占 78% × 77%) |
+| 默认窗口 | 按屏幕取 78% × 82%,钳进 [940×620, 1400×900] 后居中。上限是因为正文列宽固定 612,窗口再宽多出来的全是空白 |
 | 最小窗口 | 940 × 620 |
 | 窗口顶部 | macOS 主窗口使用 44px 透明标题栏，交通灯与拖拽区收在侧栏顶部；Windows 用原生标题栏，Linux 视 compositor 装饰协商而定 |
 | 资料库侧栏 | 224px 固定宽度 |
@@ -46,7 +46,7 @@ Wake 的目标不是展示技术感，而是让用户在几秒内重新找到并
 
 ## 颜色
 
-所有颜色必须来自 `theme.rs` 的语义 token(含 MODEL_BADGE_BG/STAR_YELLOW 两个专用常量);其他 UI 文件禁止颜色字面量。Agent 品牌资产只能来自 `AgentId::brand_icon(dark)`(内嵌 PNG 路径,定义在 `wake-core/src/models.rs`),加新 agent 时一处改完。
+所有颜色必须来自 `theme.rs` 的语义 token(含 STAR_YELLOW 常量,以及对话区专用的 `bubble_bg` / `panel_bg` / `panel_border` / `inline_code_bg` 四个随模式取值的函数);其他 UI 文件禁止颜色字面量。Agent 品牌资产只能来自 `AgentId::brand_icon(dark)`(内嵌 PNG 路径,定义在 `wake-core/src/models.rs`),加新 agent 时一处改完。
 
 ### 主要材质
 
@@ -85,9 +85,10 @@ Wake 的目标不是展示技术感，而是让用户在几秒内重新找到并
 |---|---|---|---|---|
 | Title | `FONT_TITLE` | 22px | Semibold | 中栏上下文大标题 |
 | Heading | `FONT_HEADING` | 16px | Semibold | 详情页会话标题、空态主标题 |
-| Msg user | `FONT_MSG_USER` | 13.5px | Regular | 对话区用户气泡正文 |
-| Msg body | `FONT_MSG_BODY` | 13px | Regular | 对话区助手正文 |
-| Msg thinking | `FONT_MSG_THINKING` | 11.5px | Italic | 对话区 thinking 摘要 |
+| Msg user | `FONT_MSG_USER` | 14px | Regular | 对话区用户气泡正文 |
+| Msg body | `FONT_MSG_BODY` | 14.5px | Regular | 对话区助手正文 |
+| Msg thinking | `FONT_MSG_THINKING` | 12.5px | Regular | thinking / 工具卡头行与折叠内容 |
+| Msg mono | `FONT_MSG_MONO` | 11.75px | Mono | 工具卡的参数与输入输出 |
 | Body | `FONT_BODY` | 14px | Regular(列表/搜索结果标题 Medium) | 导航行、**侧栏组头**、列表标题、按钮、输入、对话框正文 |
 | Caption | `FONT_CAPTION` | 12px | Regular | 列表副行、元信息、占位、空态提示、路径 chip、侧栏子级行 |
 | Label | `FONT_LABEL` | 11px | Regular | 计数、快捷键徽标、状态栏、会话行与详情头元信息 |
@@ -141,45 +142,74 @@ macOS 不设置横跨三栏的自定义 header。主窗口透明标题栏高 44p
 
 ### 会话流
 
-- 顶部由 22px 上下文标题、会话总数角标和 icon-only 排序按钮组成；整个标题区固定为 88px，与左栏顶部身份区等高。标题和会话总数保持 2px 紧凑间距，并作为一个信息组在 88px 内整体垂直居中，禁止拆成两条 44px 行。排序按钮与信息组顶部对齐，沿用 16px 图标、透明 ghost 常态和 6px 圆角；当前排序字段和方向放在 tooltip 与菜单选中态中。
-- 会话流固定 336px；顶部使用 22px 上下文标题、Label 11 会话数量和 icon-only 排序按钮。
-- 会话行使用 Body 14 标题与 Label 11 元信息，共两行；行内 `SPACE_SM` 上下内边距 + `SPACE_XS` 两行间距。
-- 第二行固定为品牌图标 15px、项目名 badge、弹性空隙和右对齐的智能时间；一分钟内显示 Just now，一小时内显示分钟数，当天显示时间，昨天显示 Yesterday，本年显示月日，更早补年份。Hover 统一显示精确到秒的本地时间。
-- 分支、token 和归档状态不在列表重复展示，移入详情元信息。
-- 收藏和置顶允许以 11px 系统蓝图标出现在标题尾部。
+- 顶部由 22px 上下文标题与会话总数角标组成,右侧是 icon-only 排序按钮(当前排序方式由 tooltip 给出)。总数取全库计数,与侧栏 All Sessions 同源。
+- **按时间分组**:Today / Yesterday / Earlier this week / 月份,组头 Label 11 semibold muted。仅在按更新/创建时间**倒序**时分组——按消息数排序时时间不单调,分组会碎成一堆单元素组;正序时组头顺序会反着读。
+- 会话行两行:第一行只有标题(Body 14 medium),第二行是元信息。**标题必须是行容器的直接子级**,理由见下方「文字截断」。
+- 第二行固定为:品牌图标 14px → 项目名 badge → ` · ` → 消息数 → 弹性空隙 → 收藏/置顶 → 相对时间。
+- **agent 品牌图标固定保留**,它是每行的身份锚点,不做"当前范围内 agent 唯一就省略"的优化。
+- model 不进列表:336px 的列放不下"项目 + 消息数 + model + 时间",硬塞会把项目名挤成两三个字。model 在详情页元信息带里。
+- 列表被 limit 截断时,底部用一条 hairline + Label 档说明"Showing the N most recent of M",不静默截断。
+- 空态按状态分四种:扫描中(索引进度)、扫描失败(错误)、有筛选无结果、全库为空。**扫描期间不得报"没有匹配项"**——那时既没有筛选也没有查询。
 - 当前行使用低饱和蓝材质，不额外描边。
 - 会话流不重复提供全文搜索入口；列表内输入只筛选当前范围。
 
 ### 详情头部
 
-层级从上到下为：
+**只有两层**(2026-08-26 改版,原为六层):
 
-1. Agent、项目、分支等来源上下文与右侧操作工具条，共享一个 44px 高的 Flex 行；28px 操作条上下各保留 8px，不使用绝对定位。
-2. 会话标题独占第二个 44px 行，与第一行合计 88px；标题行下沿与左栏身份区和会话列表标题区对齐。标题保持 22px，过长时单行截断。
-3. 模型、来源（Via）badge 与消息数/token 共处标题下方第一行；统计文本弹性占据剩余宽度，窄窗口下单行截断。
-4. 项目路径独占第二行。
-5. 第三行以 12px 日期图标开头，创建与更新信息复用会话列表的智能时间，两者以留白和低对比度中点明确分组；Hover 对应时间时统一展示精确到秒的完整本地时间。
-
-五层信息一项不减；标题下方的三行信息不压进 88px 标题区域。元信息区与标题、底部分隔线均保留 8px，层间保持 8px，让来源、标题、运行统计、位置和时间上下文能被分别扫读。
+1. 22px 会话标题(**单行**,按可用宽度自截断 + 全文 tooltip)与操作区。
+2. 单条元信息带:品牌图标 13px · Agent 名 · 项目名 · git 分支 · model · source 徽标 · 消息数 · token · 相对时间,全部 Label 档 muted,用 ` · ` 串起。
 
 “在终端继续”是唯一主按钮。收藏、置顶保留为独立图标按钮；导出、Finder 和删除进入“更多”菜单。按钮圆角固定 6px，危险操作在菜单中用分组隔开并继续走确认框。
 
-详情正文使用 `popover` 阅读底色，与 `background` 详情头形成明确分区；阅读面横向铺满且不套大号圆角卡。内容限制在 720px 阅读宽度并居中。助手正文保持平铺，不在每条回复前重复 Agent 署名。只有 thinking、没有回复正文或工具调用的中间事件不进入阅读视图；带正文的 thinking 摘要保留，工具调用继续默认折叠。
+三处信息**收进 tooltip 或菜单,不再占位**:
+
+- 项目完整路径 → 项目名的 tooltip(点击仍然 Reveal)。
+- 精确到秒的 Created / Updated → 相对时间的 tooltip。
+- 会话 JSONL 文件路径 → 整行删除。中段是 UUID,对人零价值;Reveal 入口在 `…` 菜单里已经有了。
+
+两条隐藏规则:git 分支为 `HEAD` / `detached` / 空时整块不渲染(detached HEAD 下透传的 "HEAD" 零信息量);model 用同级 muted 文字而**不是** badge——原先那个 outline badge 用的是 Claude 橙,却被套在所有 agent 上,与"品牌色只表达 agent 身份"自相矛盾。
 
 对话框标题一律 Heading 16 semibold:组件内建 `.title()` 不设字号(实渲窗口默认 14px),必须显式补 `text_size(FONT_HEADING)`。破坏性确认的主按钮点名动作并用 danger 形态("Move to Trash",Windows 上经 trash_copy! 平台文案为 "Move to Recycle Bin",不留裸 "OK");表单弹窗内控件同档取齐(输入框与下拉/浏览钮同高,次级动作行才允许 small)。
 
 ### 对话阅读面
 
-正文横向铺在 `popover` 材质阅读面中，与 `background` 详情头用 hairline 分开，不再套圆角大卡。助手正文 13px、用户正文 13.5px，可选择、可滚动，代码继续使用 tree-sitter 高亮。
+正文位于 `popover` 材质的 12px 圆角阅读卡中，外层使用 `background`。渲染形制对标 Claude Desktop(2026-08-26 用户定)。
 
-对话角色不使用常驻标题或 emoji：
+**角色由形态区分,不用文字标签**:
 
-- 用户使用靠右的低饱和引用块。
-- 助手正文平铺，不在每条回复前重复 Agent 名称。
-- 仅有 thinking、没有正文或工具的中间事件不进入阅读视图；带正式回复的思考摘要显示 `Thinking · …`。
-- 工具调用合并为折叠簇，失败项才内联输出。
+- 用户消息 = 右对齐气泡,`RADIUS_BUBBLE` 18px 圆角、`bubble_bg` 暖灰底、最大宽 `BUBBLE_MAX_W`、内边距 17×11。
+- 助手消息 = 全宽平铺,无气泡无标签。
+- `Context compacted` 与 System 消息 = 居中胶囊。
 
-emoji 不再承担界面或正文结构图标职责。
+**三个数是一组,必须一起改**:正文 `FONT_MSG_BODY` 14.5px、行高 `LINE_HEIGHT_PROSE` 1.92、列宽 `PROSE_MAX_W` 612px ≈ 42 个中文字/行。只提字号会让每行字数更少,只放宽容器会让行更长,单调任何一个都比原状更糟。气泡收半档(14px / 1.8),因为它有底色,同字号会显得更重。
+
+行高取 1.92 而不是西文常用的 1.5–1.6:汉字没有 x-height 起伏,字面率高,靠行距拉开视觉通道。段间距 `PROSE_PARAGRAPH_GAP` 1.05rem(=14.7px)比行距再大半档,段落边界才读得出来。
+
+**字间距调不了**:gpui 0.2.2 的 `Styled` 没有 `letter_spacing`,中西文混排的补偿只能靠行距和行宽间接缓解。
+
+**markdown 层级走组件内置能力**(`TextView` 已支持 table / blockquote / divider / 标题分级 / tree-sitter 高亮),UI 层只做样式覆写,不自己解析:
+
+- 标题分级经 `heading_font_size`:h1 ×1.45 / h2 ×1.28 / h3 ×1.14 / h4 ×1.05,再往下与正文同号靠字重区分。对话里的标题不该有网页 h1 的体量(组件默认是近两倍),但也不能差得太小,否则标题会混进正文。
+- **标题从 markdown 里切出来单独渲染**(`workbench::markdown_message` + `split_markdown_blocks`),上间距由 `heading_top_gap(level)` 按层级给:h1 30 / h2 25 / h3 20 / h4+ 16px。
+
+  为什么必须切:组件的标题渲染只有 `pb(rems(0.3))`、**没有 `pt`**(`node.rs` 的 `Node::Heading` 分支),标题上方的间距完全来自前一个块的 `paragraph_gap`——和两个普通段落之间一模一样,所以标题读不出层级。调大 `paragraph_gap` **不解决问题**:它把段间距和标题上间距一起放大,相对关系不变。`TextViewStyle` 也没有对应钩子。
+
+  代价:一条消息会拆成多个 `TextView` 实例,**跨块的文字选择会断在块边界**。切块只按 ATX 标题(`# ` ~ `###### `),并跟踪围栏代码块状态,代码里的 `# ` 注释不会被误判。
+- 块间距 `PROSE_PARAGRAPH_GAP` 1.05rem(14.7px),只管段落 / 列表 / 代码块 / 表格之间。
+- 代码块经 `TextViewStyle::code_block` 套 `panel_bg` + `panel_border` + `RADIUS_PANEL`;右上角经 `code_block_actions` 挂"语言名 + 复制"。组件把 actions 绝对定位在块内右上,做不了横跨顶部的工具栏,所以两者合成一个胶囊。
+- **代码块跟随深浅切换有两个坑,两处都必须做**:
+  1. `TextViewStyle.highlight_theme` 要显式按模式给 `default_dark()` / `default_light()`。默认值恒为 light;而且 `TextViewStyle` 的 `PartialEq` **只**比较 `paragraph_gap` / `heading_base_font_size` / `highlight_theme`——`is_dark` 与 `code_block` 都不参与,不换 highlight_theme 的话新旧 style 会被判定相等,组件根本不重建。
+  2. `TextView` 的 **id 要带上深浅模式**。它只在首次 `request_layout` 时同步解析,之后 style 变化走异步更新通道,带 200ms debounce + 后台线程重新解析(`UpdateFuture::new(.., Duration::from_millis(200), ..)`);而语法高亮的颜色是在**解析阶段**固化进 `CodeBlock.styles` 的,于是切换主题后代码块要慢一拍才变色。id 带上模式后,主题一换就被当作新元素,走首次的同步解析路径。
+
+**thinking 与工具调用都是可折叠面板**(`RADIUS_PANEL` 圆角 + `panel_bg` + `panel_border`),视觉上比正文退后一档:
+
+- thinking 收起时头行给一句摘要,展开是完整原文。不得再做成"永久截断的一行"。
+- 工具卡头行 = chevron + 名称 + **参数摘要** + 结果徽标。收起时就要看得出操作对象,只给工具名等于没有信息。
+- 展开后逐条给 Input 与 Output。**成功调用的输出同样要显示**——只留失败项等于把绝大多数工具结果丢掉,而这是个"回看历史"的工具。
+- 单条调用时头行已给出参数,展开体不再重复名称;多条时头行给数量与名字序列。
+
+emoji 不承担界面或正文结构图标职责。
 
 ### 空态
 
@@ -195,6 +225,31 @@ emoji 不再承担界面或正文结构图标职责。
 - 结果行使用品牌图标、标题、项目与时间、单行片段。
 - 搜索始终覆盖全部会话；页脚左侧显示“搜索范围：全部会话”，右侧显示 `↑↓`、`↩`、`esc` 键盘路径。
 - 指针回调中不得同步派发新的键盘事件。需要关闭旧浮层或转移输入焦点时，应通过对应组件 API 或延迟到下一事件周期处理，避免在 AppKit `mouseUp` 路径里重入 GPUI 事件分发；打开搜索面板前必须让 Root 先保存原焦点，关闭后 `⌘K` 才能继续生效。
+
+## 文字截断(gpui 0.2.2 限制)
+
+**`.truncate()` / `.text_ellipsis()` 在会话流与阅读区都不画省略号。**
+
+gpui 在 `elements/text.rs:357` 只有拿到 `known_dimensions.width` 或 `AvailableSpace::Definite` 时才截断加 `…`;虚拟列表(`v_virtual_list`)行内与 flex 子项拿不到确定宽度,文字于是按 max-content 铺开,再被外层 `overflow_hidden` 硬裁——中文正好切在半个字上。
+
+排查时试过四种结构,**都不出省略号**:标题带 `flex_1()`、去掉 `flex_1` 配弹性占位、把标题提成行容器的直接子级、去掉 `ListItem` 的 `mx`。
+
+给文字元素显式 `.w()` **也不管用**——省略号照样不画。所以定宽区域的文字一律走 `format::clip_display(s, cells)` 按**显示宽度**自截断(CJK / 全角记 2 格,其余记 1 格),并配 `overflow_hidden() + whitespace_nowrap()` 兜底:
+
+| 位置 | 格数来源 | 依据 |
+|---|---|---|
+| 会话行标题 | `TITLE_CELLS` = 42(常量) | 会话流列宽写死 336px,阈值稳定 |
+| 会话行项目名 | `PROJECT_CELLS` = 14(常量) | 与消息数、时间共享第二行 |
+| 详情页标题 | `cells_for(title_w, CELL_PX_TITLE)` | 窗口宽 − 侧栏 − 会话流 − 内边距 − 操作区 |
+| 工具卡参数 | `cells_for(prose_w − 151, CELL_PX_MONO)` | 正文实际列宽(窄窗口下小于 `PROSE_MAX_W`) |
+
+三条硬约束:
+
+1. **宽度会变的地方,格数必须从当前像素宽反算,不能写死。** 阅读区宽度随窗口拖拽变化,写死格数会让"窗口拉宽后截断长度不补齐"——这是实打实的 bug,不是取舍。`cells_for()` 每帧从 `window.viewport_size()` 重算。
+2. **省略号自己占两格。** `…` 是全角,`clip_display` 里给它留 2 格而不是 1 格;只留 1 格时截出来的串会超出容器,`…` 正好落在边界外被裁,看起来就是"截断了但没有省略号"。有单测钉住这条。
+3. **列表行绝不允许换行。** `List` 只测量一行的高度然后套给所有行(`list.rs:406`),一行变两行会把后面每一行都挤错位。格数是估算值,所以 `whitespace_nowrap()` 必须留着。
+
+上游哪天修好 `text_overflow`,连同 `clip_display` 的调用点一起删掉即可。
 
 ### Insights
 

--- a/crates/wake/Cargo.toml
+++ b/crates/wake/Cargo.toml
@@ -26,5 +26,17 @@ reqwest.workspace = true
 # 不做 target 门控:build-dependencies 的 [target.*] 匹配语义在 host/target
 # 之间有历史歧义,门控错方向 build.rs 直接解析失败;它是纯 Rust 小依赖,
 # 三平台无条件编译换四种 host×target 组合全对
+# NSWindow.titlebarSeparatorStyle:gpui 只设了 titlebarAppearsTransparent,
+# 没关掉系统的标题栏分隔线,深色下窗口顶边会留一条亮线。见 src/macos.rs。
+# objc 已经在 gpui 的依赖树里,这里只是直接引用,不新增编译单元
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"
+
+# objc 0.2 的 msg_send! 宏展开里带着老式的 cfg(feature = "cargo-clippy"),
+# 警告落在调用点而不是宏自己身上,函数级/模块级 allow 都压不住。
+# 这里只把这一个值声明为已知,其余 unexpected_cfg 照常报
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [build-dependencies]
 winresource = "0.1"

--- a/crates/wake/src/format.rs
+++ b/crates/wake/src/format.rs
@@ -1,36 +1,33 @@
-use chrono::{DateTime, Datelike, Duration, Local, TimeZone};
+use chrono::{Local, TimeZone};
 
-/// 会话时间的渐进式展示：越近越强调新鲜度，越远越强调日期锚点。
-pub fn smart_time(ts: i64) -> String {
-    smart_time_from(ts, &Local::now())
-}
-
-fn smart_time_from(ts: i64, now: &DateTime<Local>) -> String {
+/// 详情页时间信息：保留到秒，避免相对时间丢失会话的精确时间上下文。
+/// 列表与元信息带用的紧凑相对时间。扫读锚点要短:会话流第二行要同时
+/// 放下 agent 图标、项目 chip、消息数,`23 min ago` 这类长形式只能从
+/// 项目名身上砍宽度。完整时间在 tooltip 里。
+pub fn relative_time(ts: i64) -> String {
     if ts <= 0 {
         return String::new();
     }
-
-    let Some(dt) = Local.timestamp_millis_opt(ts).single() else {
-        return String::new();
-    };
-    let diff = now.timestamp_millis() - ts;
+    let now = chrono::Utc::now().timestamp_millis();
+    let diff = now - ts;
     const MIN: i64 = 60_000;
-    if (0..MIN).contains(&diff) {
-        "Just now".to_string()
-    } else if (MIN..60 * MIN).contains(&diff) {
-        format!("{} min ago", diff / MIN)
-    } else if dt.date_naive() == now.date_naive() {
-        dt.format("%-I:%M %p").to_string()
-    } else if dt.date_naive() == now.date_naive() - Duration::days(1) {
-        "Yesterday".to_string()
-    } else if dt.year() == now.year() {
-        dt.format("%b %-d").to_string()
+    if diff < MIN {
+        "now".to_string()
+    } else if diff < 60 * MIN {
+        format!("{}m", diff / MIN)
+    } else if diff < 24 * 60 * MIN {
+        format!("{}h", diff / (60 * MIN))
+    } else if diff < 7 * 24 * 60 * MIN {
+        format!("{}d", diff / (24 * 60 * MIN))
     } else {
-        dt.format("%b %-d, %Y").to_string()
+        Local
+            .timestamp_millis_opt(ts)
+            .single()
+            .map(|d| d.format("%m-%d").to_string())
+            .unwrap_or_default()
     }
 }
 
-/// 详情页时间信息：保留到秒，避免相对时间丢失会话的精确时间上下文。
 pub fn abs_date(ts: i64) -> String {
     if ts <= 0 {
         return String::new();
@@ -130,6 +127,40 @@ pub fn expand_tilde(p: &str) -> String {
     }
 }
 
+/// 按显示宽度截断并补省略号。CJK / 全角记 2 格,其余记 1 格。
+///
+/// 代替 gpui 的 `truncate()`:后者只在布局时拿到 `known_dimensions.width`
+/// 或 `AvailableSpace::Definite` 才画省略号(`elements/text.rs:357`),
+/// 虚拟列表行与 flex 子项都拿不到,文字会按 max-content 铺开再被
+/// `overflow_hidden` 硬裁在半个字上。
+pub fn clip_display(s: &str, cells: usize) -> String {
+    let width = |c: char| {
+        if (c as u32) >= 0x1100 && !c.is_ascii() {
+            2
+        } else {
+            1
+        }
+    };
+    let total: usize = s.chars().map(width).sum();
+    if total <= cells {
+        return s.to_string();
+    }
+    // `…` 是全角,占两格;只留一格会让结果超出容器、省略号被裁掉
+    let budget = cells.saturating_sub(2);
+    let mut used = 0;
+    let mut out = String::new();
+    for c in s.chars() {
+        let w = width(c);
+        if used + w > budget {
+            break;
+        }
+        used += w;
+        out.push(c);
+    }
+    out.push('…');
+    out
+}
+
 /// 首行截断预览
 pub fn one_line(s: &str, max_chars: usize) -> String {
     let joined = s.split_whitespace().collect::<Vec<_>>().join(" ");
@@ -144,43 +175,47 @@ pub fn one_line(s: &str, max_chars: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod clip_tests {
+    use super::clip_display;
 
-    fn local_time(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> DateTime<Local> {
-        Local
-            .with_ymd_and_hms(year, month, day, hour, minute, 0)
-            .single()
-            .expect("test date should be unambiguous in the local timezone")
+    #[test]
+    fn keeps_short_text_untouched() {
+        assert_eq!(clip_display("hello", 20), "hello");
+        assert_eq!(clip_display("中文标题", 20), "中文标题");
     }
 
     #[test]
-    fn smart_time_uses_progressive_precision() {
-        let now = local_time(2026, 8, 26, 18, 0);
+    fn cjk_counts_as_two_cells() {
+        assert_eq!(clip_display("中文标题", 6), "中文…");
+    }
 
-        assert_eq!(
-            smart_time_from((now - Duration::seconds(30)).timestamp_millis(), &now),
-            "Just now"
-        );
-        assert_eq!(
-            smart_time_from((now - Duration::minutes(23)).timestamp_millis(), &now),
-            "23 min ago"
-        );
-        assert_eq!(
-            smart_time_from(local_time(2026, 8, 26, 15, 42).timestamp_millis(), &now),
-            "3:42 PM"
-        );
-        assert_eq!(
-            smart_time_from(local_time(2026, 8, 25, 12, 0).timestamp_millis(), &now),
-            "Yesterday"
-        );
-        assert_eq!(
-            smart_time_from(local_time(2026, 8, 21, 12, 0).timestamp_millis(), &now),
-            "Aug 21"
-        );
-        assert_eq!(
-            smart_time_from(local_time(2025, 8, 21, 12, 0).timestamp_millis(), &now),
-            "Aug 21, 2025"
-        );
+    #[test]
+    fn ascii_counts_as_one_cell() {
+        assert_eq!(clip_display("abcdefgh", 5), "abc…");
+    }
+
+    #[test]
+    fn never_splits_a_char() {
+        // 省略号 2 格 + 内容 3 格,第二个汉字放不下
+        assert_eq!(clip_display("中文标题", 5), "中…");
+    }
+
+    #[test]
+    fn reserves_room_for_the_ellipsis() {
+        let width = |s: &str| -> usize {
+            s.chars()
+                .map(|c| {
+                    if (c as u32) >= 0x1100 && !c.is_ascii() {
+                        2
+                    } else {
+                        1
+                    }
+                })
+                .sum()
+        };
+        for cells in 4..40 {
+            assert!(width(&clip_display("一二三四五六七八九十", cells)) <= cells);
+            assert!(width(&clip_display("abcdefghijklmnopqrst", cells)) <= cells);
+        }
     }
 }

--- a/crates/wake/src/macos.rs
+++ b/crates/wake/src/macos.rs
@@ -1,0 +1,42 @@
+//! macOS 专属的窗口调校。
+//!
+//! gpui 把窗口设成 `titlebarAppearsTransparent = YES`,但没有动
+//! `titlebarSeparatorStyle`。该属性默认 `Automatic`,系统会在标题栏与内容
+//! 之间自行画分隔线;深色下是一条亮线。gpui 未暴露此开关,走 objc 运行时关。
+
+/// 关掉所有窗口的标题栏分隔线。每次开窗后调用。
+#[cfg(target_os = "macos")]
+pub fn suppress_titlebar_separator() {
+    use objc::runtime::{Object, BOOL, YES};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    /// `NSTitlebarSeparatorStyleNone`
+    const SEPARATOR_NONE: i64 = 1;
+
+    unsafe {
+        let app: *mut Object = msg_send![class!(NSApplication), sharedApplication];
+        if app.is_null() {
+            return;
+        }
+        let windows: *mut Object = msg_send![app, windows];
+        if windows.is_null() {
+            return;
+        }
+        let count: usize = msg_send![windows, count];
+        for ix in 0..count {
+            let window: *mut Object = msg_send![windows, objectAtIndex: ix];
+            if window.is_null() {
+                continue;
+            }
+            // macOS 11+ 的 API
+            let responds: BOOL =
+                msg_send![window, respondsToSelector: sel!(setTitlebarSeparatorStyle:)];
+            if responds == YES {
+                let _: () = msg_send![window, setTitlebarSeparatorStyle: SEPARATOR_NONE];
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn suppress_titlebar_separator() {}

--- a/crates/wake/src/main.rs
+++ b/crates/wake/src/main.rs
@@ -8,6 +8,7 @@
 
 mod assets;
 mod format;
+mod macos;
 mod settings;
 mod theme;
 mod ui;
@@ -72,7 +73,23 @@ fn main() {
             },
         ]);
 
-        let bounds = Bounds::centered(None, size(px(1180.), px(760.)), cx);
+        // 按屏幕比例取,再钳进 [最小, 理想]。给上限是因为正文列宽固定 612,
+        // 窗口再宽多出来的只是空白
+        const IDEAL: Size<Pixels> = Size {
+            width: px(1400.),
+            height: px(900.),
+        };
+        let win_size = cx
+            .primary_display()
+            .map(|display| {
+                let screen = display.bounds().size;
+                size(
+                    (screen.width * 0.78).clamp(px(940.), IDEAL.width),
+                    (screen.height * 0.82).clamp(px(620.), IDEAL.height),
+                )
+            })
+            .unwrap_or(IDEAL);
+        let bounds = Bounds::centered(None, win_size, cx);
         // macOS:隐藏系统标题栏、内容顶到窗顶,traffic light 悬浮在侧栏上;
         // Linux/Windows:标准系统标题栏(appears_transparent=false)。Windows
         // 后端按此保留原生 caption(min/max/close、snap layouts、深色模式随
@@ -135,6 +152,7 @@ fn main() {
             ));
             std::process::exit(1);
         }
+        macos::suppress_titlebar_separator();
         cx.activate(true);
     });
 }

--- a/crates/wake/src/theme.rs
+++ b/crates/wake/src/theme.rs
@@ -82,12 +82,53 @@ fn c(hex: u32) -> Hsla {
     .into()
 }
 
-/// 详情页 model badge 色——用户指定的 Claude 橙(非 agent 语义,纯配色选择);
-/// outline badge 形态,两模式通用
-pub const MODEL_BADGE_BG: u32 = 0xD97757;
-
 /// 收藏星选中色——macOS systemYellow(Finder/Mail 星标惯例),两模式通用
 pub const STAR_YELLOW: u32 = 0xFFCC00;
+
+/// 会话流日期组头的竖条色。比 agent 品牌橙更亮更饱和,避免读成身份标记
+/// ——它标的是时间分组。两模式通用
+pub const DATE_GROUP_ACCENT: u32 = 0xFF8A3D;
+
+// ---------------- 对话区专用材质 ----------------
+// 阅读卡内需要几档比 `muted` 更暖、彼此可分的面:直接复用 `theme.muted`
+// 的话,气泡里嵌代码块时两者同色、边界消失。随深浅模式变,故为函数。
+
+/// 用户气泡底
+pub fn bubble_bg(dark: bool) -> Hsla {
+    if dark {
+        c(0x37362F)
+    } else {
+        c(0xEDEBE3)
+    }
+}
+
+/// thinking / 工具卡 / 代码块的面
+pub fn panel_bg(dark: bool) -> Hsla {
+    if dark {
+        c(0x232321)
+    } else {
+        c(0xF4F3ED)
+    }
+}
+
+/// 面板与代码块的描边(极淡,只为在同色系里划出边界)
+pub fn panel_border(dark: bool) -> Hsla {
+    if dark {
+        ca(0xFFFFFF, 0.07)
+    } else {
+        ca(0x000000, 0.055)
+    }
+}
+
+/// 行内代码底,与 `theme.accent` 同值(TextView 写死取 accent,这里供
+/// 工具卡等自绘处用)。比 panel 再淡一档,免得中文段落里连着几个成斑块
+pub fn inline_code_bg(dark: bool) -> Hsla {
+    if dark {
+        c(0x3B3830)
+    } else {
+        c(0xF1EFE8)
+    }
+}
 
 /// 在 gpui-component 默认主题之上覆写 Wake 的 token。
 /// 每次外观切换后都要重新调用(sync_system_appearance 会重置为默认)。
@@ -119,7 +160,9 @@ pub fn apply_wake_theme(cx: &mut App) {
 
         theme.muted = c(0x323230);
         theme.muted_foreground = c(0xA9A8A2);
-        theme.accent = c(0x383836);
+        // accent 同时是 TextView 里行内代码的底色(组件 node.rs:651 写死
+        // 取它,没有单独钩子),故与 inline_code_bg 取同一档暖色
+        theme.accent = c(0x3B3830);
         theme.accent_foreground = c(0xF4F3F0);
 
         theme.primary = c(0x4C8DFF);
@@ -181,7 +224,8 @@ pub fn apply_wake_theme(cx: &mut App) {
 
         theme.muted = c(0xE8E8E5);
         theme.muted_foreground = c(0x686761);
-        theme.accent = c(0xE7E7E3);
+        // 同深色分支:accent 也是行内代码底色
+        theme.accent = c(0xF1EFE8);
         theme.accent_foreground = c(0x1D1D1F);
 
         theme.primary = c(0x0A84FF);

--- a/crates/wake/src/ui.rs
+++ b/crates/wake/src/ui.rs
@@ -17,14 +17,66 @@ pub const FONT_CAPTION: Pixels = px(12.);
 /// 标签(分组头/计数/快捷键徽标/状态栏);组头 semibold + 大写
 pub const FONT_LABEL: Pixels = px(11.);
 
-// ---- 对话区附档(详情逐消息渲染,经用户逐轮校准,与六档并存)----
+// ---- 对话区附档(详情逐消息渲染,与六档并存)----
+// 字号 / 行宽 / 行高是一组,必须一起改:14.5px × 612px ≈ 42 个中文字/行。
+// 只动字号会让每行字数漂,列宽要按同一比例跟着走。
 
-/// 用户气泡正文(比 FONT_BODY 收半档,气泡内更紧凑)
-pub const FONT_MSG_USER: Pixels = px(13.5);
+/// 用户气泡正文(比助手正文收半档:气泡有底色,同字号会显得更重)
+pub const FONT_MSG_USER: Pixels = px(14.);
 /// 助手平铺正文
-pub const FONT_MSG_BODY: Pixels = px(13.);
-/// thinking 摘要行(斜体)
-pub const FONT_MSG_THINKING: Pixels = px(11.5);
+pub const FONT_MSG_BODY: Pixels = px(14.5);
+/// thinking / 工具卡的头行与折叠内容
+pub const FONT_MSG_THINKING: Pixels = px(12.5);
+/// 工具卡里的等宽参数与输出
+pub const FONT_MSG_MONO: Pixels = px(11.75);
+
+/// 助手正文行高。中文长文的舒适区间 1.85–2.0——汉字没有 x-height 起伏,
+/// 西文常用的 1.5–1.6 会明显发挤
+pub const LINE_HEIGHT_PROSE: f32 = 1.92;
+/// 用户气泡行高——气泡内有内边距兜住,比平铺正文收一点更紧凑
+pub const LINE_HEIGHT_BUBBLE: f32 = 1.8;
+
+/// 对话内容列宽,与 FONT_MSG_BODY 绑定(14.5 × 42 ≈ 612)。
+/// 阅读区再宽正文也停在这里并居中:中文超过 ~42 字/行回行容易串行
+pub const PROSE_MAX_W: Pixels = px(612.);
+/// 用户气泡最大宽度(≈ 正文列宽的 78%,右对齐时留出可辨的左侧缺口)
+pub const BUBBLE_MAX_W: Pixels = px(478.);
+
+/// 段落等块级元素之间的间距(rem 基准被 Root 钉在 14px)。
+/// 标题上方的间距不走这里,见 `workbench::heading_top_gap`。
+pub const PROSE_PARAGRAPH_GAP: f32 = 1.05;
+
+// ---------------- 三栏宽度 ----------------
+// 侧栏与会话流固定宽,阅读区吃剩余。详情页按窗口宽反算标题可用宽度,
+// 所以这两个数必须是常量而非 render 里的字面量。
+
+/// 资料库侧栏宽度
+pub const SIDEBAR_W: Pixels = px(224.);
+/// 会话流宽度
+pub const STREAM_W: Pixels = px(336.);
+/// 详情头部右侧操作区的实测占宽(Resume 分段钮 + 星 + 钉 + 更多 + 间距),
+/// 标题可用宽度由窗口宽减去它反推。改动操作区按钮数量时要重新实测
+pub const DETAIL_ACTIONS_W: Pixels = px(196.);
+
+// ---------------- 字宽 → 格数 ----------------
+// 定宽处的文字走 `format::clip_display` 自截断。宽度会变的地方,格数必须
+// 从当前像素宽反算而不是写死,否则窗口拖宽后截断长度不会补齐。
+// 一格 = 一个 ASCII 字符宽(CJK 记 2 格);下面是各字号实测的每格像素。
+
+/// FONT_TITLE 22px semibold
+pub const CELL_PX_TITLE: f32 = 10.5;
+/// FONT_MSG_MONO 11.75px 等宽
+pub const CELL_PX_MONO: f32 = 7.05;
+
+/// 可用像素宽 → 可容纳的格数
+pub fn cells_for(width: Pixels, cell_px: f32) -> usize {
+    ((f32::from(width) / cell_px) as usize).max(8)
+}
+
+/// 用户气泡圆角(Claude Desktop 形制,比面板圆得多)
+pub const RADIUS_BUBBLE: Pixels = px(18.);
+/// thinking / 工具卡 / 代码面的圆角
+pub const RADIUS_PANEL: Pixels = px(10.);
 
 // ---------------- 平台文案 ----------------
 // 同一处 UI 在不同平台叫不同名字/键(Finder vs File Explorer vs 文件管理器、
@@ -143,6 +195,9 @@ pub const RADIUS_BUTTON: Pixels = px(6.);
 pub const RADIUS_KBD: Pixels = px(5.);
 /// 小胶囊 badge(项目名 / model / source / 各处计数共用)
 pub const RADIUS_BADGE: Pixels = px(4.);
+/// 数据可视化里的小色块(热力图格子、柱条)。11px 的格子用 4px 圆角会显得
+/// 发圆、丢掉方格的读数感,单独一档
+pub const RADIUS_CELL: Pixels = px(2.);
 
 // ---------------- 组件度量派生 ----------------
 

--- a/crates/wake/src/workbench.rs
+++ b/crates/wake/src/workbench.rs
@@ -24,6 +24,7 @@ use futures::StreamExt;
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::button::{Button, ButtonCustomVariant, ButtonVariants as _};
+use gpui_component::highlighter::HighlightTheme;
 use gpui_component::input::{Input, InputEvent, InputState};
 use gpui_component::list::{List, ListDelegate, ListEvent, ListItem, ListState};
 use gpui_component::menu::{DropdownMenu as _, PopupMenuItem};
@@ -46,7 +47,8 @@ use wake_core::services::{exporter, terminal};
 use wake_core::watcher::{start_watcher, SessionWatcher};
 
 use crate::format::{
-    abs_date, expand_tilde, fmt_tokens, month_year, one_line, smart_time, thousands, tilde_path,
+    abs_date, clip_display, expand_tilde, fmt_tokens, month_year, one_line, relative_time,
+    thousands, tilde_path,
 };
 use crate::settings::{SettingsPage, SettingsView};
 use crate::ui::*;
@@ -121,13 +123,151 @@ impl ScanEvents for ChannelEvents {
 
 pub struct SessionsDelegate {
     pub sessions: Vec<SessionMeta>,
+    /// 按时间分好的组:(组头文案, 在 `sessions` 里的下标区间)。
+    /// 存区间而不是各存一份 SessionMeta——那是十几个 String 字段的深拷贝。
+    /// 不分组时是单个组名为空的组,`render_section_header` 返回 None。
+    groups: Vec<(SharedString, std::ops::Range<usize>)>,
+}
+
+impl SessionsDelegate {
+    fn new(sessions: Vec<SessionMeta>, sort: SortKey, ascending: bool) -> Self {
+        let groups = build_groups(&sessions, sort, ascending);
+        Self { sessions, groups }
+    }
+
+    /// IndexPath → `sessions` 的扁平下标
+    fn flat_index(&self, ix: IndexPath) -> Option<usize> {
+        let (_, range) = self.groups.get(ix.section)?;
+        let flat = range.start + ix.row;
+        (flat < range.end).then_some(flat)
+    }
+
+    /// 扁平下标 → IndexPath(选中与滚动定位用)
+    fn index_path(&self, flat: usize) -> Option<IndexPath> {
+        let (section, (_, range)) = self
+            .groups
+            .iter()
+            .enumerate()
+            .find(|(_, (_, r))| r.contains(&flat))?;
+        Some(IndexPath::new(flat - range.start).section(section))
+    }
+}
+
+/// 把会话切成 Today / Yesterday / Earlier this week / … 的时间组。
+///
+/// 只在**时间倒序**下分组:按消息数排序时时间不单调,分组会碎成一堆单元素
+/// 组;正序时组头顺序会反着读。其余情况退回单个匿名组(不渲染组头)。
+fn build_groups(
+    sessions: &[SessionMeta],
+    sort: SortKey,
+    ascending: bool,
+) -> Vec<(SharedString, std::ops::Range<usize>)> {
+    if sessions.is_empty() {
+        return Vec::new();
+    }
+    let groupable = matches!(sort, SortKey::Updated | SortKey::Created) && !ascending;
+    if !groupable {
+        return vec![(SharedString::default(), 0..sessions.len())];
+    }
+    let key_of = |s: &SessionMeta| match sort {
+        SortKey::Created => s.created_at,
+        _ => s.updated_at,
+    };
+    let mut groups: Vec<(SharedString, std::ops::Range<usize>)> = Vec::new();
+    // 置顶在 DB 层就排到了最前(ORDER BY pinned DESC),它们的时间戳与后面
+    // 的行不连续。混进时间分组会切出重复组头——置顶里有今天的、后面还有
+    // 今天的,就会出现两个 Today。单独成组
+    let pinned = sessions.iter().take_while(|s| s.pinned).count();
+    if pinned > 0 {
+        groups.push((SharedString::new_static("Pinned"), 0..pinned));
+    }
+    for (ix, s) in sessions.iter().enumerate().skip(pinned) {
+        let label = time_bucket(key_of(s));
+        match groups.last_mut() {
+            Some((last, range)) if *last == label => range.end = ix + 1,
+            _ => groups.push((label, ix..ix + 1)),
+        }
+    }
+    groups
+}
+
+/// 时间戳 → 组头文案。UI 语言英文,月份走 chrono 的英文月名。
+fn time_bucket(ts: i64) -> SharedString {
+    use chrono::{Datelike as _, Local, TimeZone as _};
+    let Some(dt) = Local.timestamp_millis_opt(ts).single() else {
+        return "Undated".into();
+    };
+    let today = Local::now().date_naive();
+    let days = (today - dt.date_naive()).num_days();
+    match days {
+        i64::MIN..=0 => "Today".into(),
+        1 => "Yesterday".into(),
+        2..=6 => "Earlier this week".into(),
+        _ if dt.year() == today.year() => dt.format("%B").to_string().into(),
+        _ => dt.format("%B %Y").to_string().into(),
+    }
 }
 
 impl ListDelegate for SessionsDelegate {
     type Item = ListItem;
 
-    fn items_count(&self, _section: usize, _cx: &App) -> usize {
-        self.sessions.len()
+    fn sections_count(&self, _cx: &App) -> usize {
+        self.groups.len()
+    }
+
+    fn items_count(&self, section: usize, _cx: &App) -> usize {
+        self.groups.get(section).map_or(0, |(_, r)| r.len())
+    }
+
+    fn render_section_header(
+        &mut self,
+        section: usize,
+        _window: &mut Window,
+        cx: &mut Context<ListState<Self>>,
+    ) -> Option<impl IntoElement> {
+        let (label, _) = self.groups.get(section)?;
+        if label.is_empty() {
+            return None;
+        }
+        let theme = cx.theme();
+        Some(
+            div()
+                .w_full()
+                .mx(SPACE_SM)
+                // 与详情头「标题 → 元信息」的 gap 同值:首组组头因此与右栏元信息
+                // 行齐平。对所有组头必须一致——List 只测量 section 0 的高度再套
+                // 给全部组头(list.rs:406);组间分隔靠线,不靠拉大间距
+                .pt(SPACE_SM)
+                .pb(SPACE_XS)
+                .child(
+                    h_flex()
+                        .w_full()
+                        .gap(px(7.))
+                        .items_center()
+                        .child(
+                            div()
+                                .w(px(3.))
+                                .h(px(11.))
+                                .flex_shrink_0()
+                                .rounded(px(1.5))
+                                .bg(rgb(crate::theme::DATE_GROUP_ACCENT)),
+                        )
+                        .child(
+                            div()
+                                .flex_shrink_0()
+                                .text_size(FONT_LABEL)
+                                .font_medium()
+                                .text_color(theme.muted_foreground)
+                                .child(label.to_uppercase()),
+                        )
+                        // 发丝线接在文字后面延伸出去,标记"这一组从这里开始"。
+                        // 首组上方就是列表顶部,无需与谁分隔,所以不画——
+                        // 线高 1px 被文字撑住,去掉它不改变组头高度
+                        .when(section > 0, |row| {
+                            row.child(div().flex_1().h(px(1.)).bg(theme.border))
+                        }),
+                ),
+        )
     }
 
     fn render_item(
@@ -136,12 +276,24 @@ impl ListDelegate for SessionsDelegate {
         _window: &mut Window,
         cx: &mut Context<ListState<Self>>,
     ) -> Option<Self::Item> {
-        let s = self.sessions.get(ix.row)?;
+        let s = self.sessions.get(self.flat_index(ix)?)?;
         let theme = cx.theme();
-        let updated_time: SharedString = smart_time(s.updated_at).into();
-        let updated_tooltip: SharedString = abs_date(s.updated_at).into();
+
+        // 行内文字全部按格数自截断(见 clip_display 的注释:gpui 的 truncate
+        // 在虚拟列表里不画省略号)。格数按 336px 列宽减去 ListItem 与行内
+        // 边距、图标、时间列之后的余量折算,列宽是固定值所以阈值稳定。
+        const TITLE_CELLS: usize = 42;
+        const PROJECT_CELLS: usize = 14;
+        // model 不进列表:336px 的列放不下"项目 + 消息数 + model + 时间",
+        // 硬塞会把项目名挤成两三个字。model 在详情页元信息带里
+        let facts = if s.message_count > 0 {
+            format!("{} messages", s.message_count)
+        } else {
+            String::new()
+        };
 
         Some(
+            // mx 是选中胶囊的左右留白
             ListItem::new(ix.row)
                 .rounded(theme.radius)
                 .mx(SPACE_SM)
@@ -150,24 +302,46 @@ impl ListDelegate for SessionsDelegate {
                         .w_full()
                         .px(SPACE_XS)
                         .py(SPACE_SM)
-                        .gap(SPACE_XS)
+                        .gap(px(5.))
+                        // 标题独占一行,星标/置顶与时间下沉到元信息行
+                        .child(
+                            div()
+                                // nowrap 是兜底:格数是估算值,超了只能裁,绝不
+                                // 能换行——List 只测一行高度套给所有行(list.rs:406)
+                                .overflow_hidden()
+                                .whitespace_nowrap()
+                                .text_size(FONT_BODY)
+                                .font_medium()
+                                .text_color(theme.foreground)
+                                .child(clip_display(&s.title, TITLE_CELLS)),
+                        )
                         .child(
                             h_flex()
                                 .gap(px(6.))
+                                .items_center()
+                                .text_size(FONT_LABEL)
+                                .text_color(theme.muted_foreground)
+                                // agent 图标固定保留,是每行的身份锚点
                                 .child(
-                                    div()
-                                        .flex_1()
-                                        .min_w_0()
-                                        .text_size(FONT_BODY)
-                                        .font_medium()
-                                        .text_color(theme.foreground)
-                                        .truncate()
-                                        .child(s.title.clone()),
+                                    img(s.agent.brand_icon(theme.mode.is_dark()))
+                                        .size(px(14.))
+                                        .flex_shrink_0(),
                                 )
+                                .child(badge(
+                                    clip_display(&s.project_name, PROJECT_CELLS),
+                                    theme.muted,
+                                    theme.muted_foreground,
+                                ))
+                                .when(!facts.is_empty(), |this| {
+                                    this.child(meta_sep(theme.muted_foreground))
+                                        .child(div().flex_shrink_0().child(facts.clone()))
+                                })
+                                .child(div().flex_1())
                                 .when(s.pinned, |this| {
                                     this.child(
                                         icon("icons/pin-filled.svg")
                                             .with_size(px(11.))
+                                            .flex_shrink_0()
                                             .text_color(theme.primary),
                                     )
                                 })
@@ -175,38 +349,11 @@ impl ListDelegate for SessionsDelegate {
                                     this.child(
                                         icon("icons/star-filled.svg")
                                             .with_size(px(11.))
+                                            .flex_shrink_0()
                                             .text_color(rgb(crate::theme::STAR_YELLOW)),
                                     )
-                                }),
-                        )
-                        .child(
-                            h_flex()
-                                .gap(px(6.))
-                                .text_size(FONT_LABEL)
-                                .text_color(theme.muted_foreground)
-                                .child(
-                                    img(s.agent.brand_icon(theme.mode.is_dark()))
-                                        .size(px(15.))
-                                        .flex_shrink_0(),
-                                )
-                                .child(badge(
-                                    s.project_name.clone(),
-                                    theme.muted,
-                                    theme.muted_foreground,
-                                ))
-                                .child(div().flex_1())
-                                .child(
-                                    div()
-                                        .id(("session-updated-time", ix.row))
-                                        .flex_shrink_0()
-                                        .child(updated_time)
-                                        .tooltip(move |window, cx| {
-                                            gpui_component::tooltip::Tooltip::new(
-                                                updated_tooltip.clone(),
-                                            )
-                                            .build(window, cx)
-                                        }),
-                                ),
+                                })
+                                .child(div().flex_shrink_0().child(relative_time(s.updated_at))),
                         ),
                 ),
         )
@@ -247,7 +394,7 @@ impl ListDelegate for SearchDelegate {
         let h = self.hits.get(ix.row)?;
         let theme = cx.theme();
         let timestamp = h.timestamp.unwrap_or(0);
-        let hit_time: SharedString = smart_time(timestamp).into();
+        let hit_time: SharedString = relative_time(timestamp).into();
         let hit_time_tooltip: SharedString = abs_date(timestamp).into();
         let snippet = h
             .snippet
@@ -415,10 +562,14 @@ struct DetailState {
     /// 过滤后的可见消息。Rc 让行渲染以引用计数克隆代替整条消息深拷贝
     transcript: Rc<Vec<TranscriptMessage>>,
     loading: bool,
+    /// 解析失败的原因。Some 时阅读区渲染错误面板
+    error: Option<SharedString>,
     /// 逐消息不等高列表(gpui 原生 ListState,惰性测量)
     msg_list: gpui::ListState,
-    /// 展开的工具簇/thinking(按消息在 transcript 里的下标)
-    expanded_rows: HashSet<usize>,
+    /// 展开的工具簇(按消息在 transcript 里的下标)
+    expanded_tools: HashSet<usize>,
+    /// 展开的 thinking。与工具簇分开存,否则两者会互相带着开
+    expanded_thinking: HashSet<usize>,
     /// 搜索跳转目标(FTS seq,契约=消息 seq);解析完成后滚到该消息并保持高亮
     jump_seq: Option<i64>,
 }
@@ -674,9 +825,7 @@ impl Workbench {
 
         let list_state = cx.new(|cx| {
             ListState::new(
-                SessionsDelegate {
-                    sessions: Vec::new(),
-                },
+                SessionsDelegate::new(Vec::new(), SortKey::Updated, false),
                 window,
                 cx,
             )
@@ -818,7 +967,8 @@ impl Workbench {
             title_query: None,
             sort: self.sort_key,
             ascending: self.sort_ascending,
-            limit: 500,
+            // 列表是虚拟滚动的,这个上限只为兜住内存;超出时中栏底部会明说
+            limit: 2000,
             offset: 0,
         }
     }
@@ -827,8 +977,11 @@ impl Workbench {
         let filter = self.current_filter();
         if let Ok((sessions, total)) = self.store.list_sessions(&filter) {
             self.total_sessions = total;
+            let (sort, ascending) = (self.sort_key, self.sort_ascending);
             self.list_state.update(cx, |state, cx| {
-                state.delegate_mut().sessions = sessions;
+                // 整体换 delegate:分组由排序方式与时间戳推出,只换数据会
+                // 留下上一轮的分组区间
+                *state.delegate_mut() = SessionsDelegate::new(sessions, sort, ascending);
                 cx.notify();
             });
         }
@@ -1112,6 +1265,8 @@ impl Workbench {
         ) {
             Ok(handle) => {
                 workbench.update(cx, |this, _| this.settings_window = Some(handle.into()));
+                // 逐窗口属性,新窗口要再关一次
+                crate::macos::suppress_titlebar_separator();
                 cx.activate(true);
             }
             Err(error) => eprintln!("failed to open Wake settings: {error}"),
@@ -1807,12 +1962,13 @@ impl Workbench {
             ListEvent::Select(ix) | ListEvent::Confirm(ix) => *ix,
             ListEvent::Cancel => return,
         };
-        let key = list
-            .read(cx)
-            .delegate()
-            .sessions
-            .get(ix.row)
-            .map(|s| s.key.clone());
+        let key = {
+            let delegate = list.read(cx).delegate();
+            delegate
+                .flat_index(ix)
+                .and_then(|flat| delegate.sessions.get(flat))
+                .map(|s| s.key.clone())
+        };
         if let Some(key) = key {
             self.open_detail(&key, None, window, cx);
         }
@@ -2078,9 +2234,11 @@ impl Workbench {
             meta: meta.clone(),
             transcript: Rc::new(Vec::new()),
             loading: true,
+            error: None,
             // Bottom 对齐 = 聊天语义:打开落在最新消息,向上翻历史
             msg_list: gpui::ListState::new(0, gpui::ListAlignment::Bottom, px(512.)),
-            expanded_rows: HashSet::new(),
+            expanded_tools: HashSet::new(),
+            expanded_thinking: HashSet::new(),
             jump_seq,
         });
         // 搜索路径:中栏列表同步选中并滚到该会话。
@@ -2094,9 +2252,16 @@ impl Workbench {
         let task = cx.background_spawn(async move {
             // adapter_for 按文件路径挑实例:自定义 location 的会话必须由
             // 拥有其根的实例解析(gemini/kimi 的 cwd 反查是实例相对侧档)
-            let adapter = adapter_for(&adapters, meta.agent, &meta.file_path)?;
+            let Some(adapter) = adapter_for(&adapters, meta.agent, &meta.file_path) else {
+                return Err(format!(
+                    "No {} reader is configured for this file.",
+                    meta.agent.display_name()
+                ));
+            };
             let r = SessionFileRef::from_meta(&meta);
-            let t = adapter.parse_transcript(&r).ok()?;
+            let t = adapter
+                .parse_transcript(&r)
+                .map_err(|e| format!("Couldn't read this session file: {e}"))?;
             let visible: Vec<TranscriptMessage> = t
                 .mainline
                 .into_iter()
@@ -2108,14 +2273,14 @@ impl Workbench {
                             || m.kind == MessageKind::CompactSummary)
                 })
                 .collect();
-            Some((meta.key.clone(), visible))
+            Ok((meta.key.clone(), visible))
         });
         cx.spawn_in(window, async move |this, cx| {
             let result = task.await;
             this.update_in(cx, |this, _window, cx| {
                 if let Some(detail) = &mut this.detail {
                     match result {
-                        Some((key, messages)) if key == detail.meta.key => {
+                        Ok((key, messages)) if key == detail.meta.key => {
                             detail.msg_list = gpui::ListState::new(
                                 messages.len(),
                                 gpui::ListAlignment::Bottom,
@@ -2138,7 +2303,12 @@ impl Workbench {
                             detail.transcript = Rc::new(messages);
                             detail.loading = false;
                         }
-                        _ => detail.loading = false,
+                        // key 不匹配 = 已切走,这一轮结果作废
+                        Ok(_) => {}
+                        Err(reason) => {
+                            detail.error = Some(reason.into());
+                            detail.loading = false;
+                        }
                     }
                 }
                 cx.notify();
@@ -2174,16 +2344,18 @@ impl Workbench {
     /// 命中可能不在列表里),中栏定位选中该会话并滚到可见
     fn sync_list_selection(&mut self, key: &str, window: &mut Window, cx: &mut Context<Self>) {
         self.show_all_sessions(window, cx);
-        let row = self
-            .list_state
-            .read(cx)
-            .delegate()
-            .sessions
-            .iter()
-            .position(|s| s.key == key);
+        let row = {
+            let delegate = self.list_state.read(cx).delegate();
+            delegate
+                .sessions
+                .iter()
+                .position(|s| s.key == key)
+                .and_then(|flat| delegate.index_path(flat))
+        };
+        // 命中排在 limit 之外时 row 为 None:详情页已开,这里只是不滚动
         if let Some(row) = row {
             self.list_state.update(cx, |state, cx| {
-                state.set_selected_index(Some(IndexPath::new(row)), window, cx);
+                state.set_selected_index(Some(row), window, cx);
                 // 组件无 strict-Top:非 Center 策略都是"最小滚动恰好可见",
                 // 目标从下方进入会贴底。先把 offset 拉到超底,deferred 消费时
                 // 目标位于视口上方,最小滚动分支即把它对齐到视口顶。
@@ -2191,7 +2363,7 @@ impl Workbench {
                 // scroll_strict 字段目前写死 false 未被读——它被接通之日,
                 // 换成 strict-Top 调用并删掉这行 set_offset
                 state.scroll_handle().set_offset(point(px(0.), px(-1e9)));
-                state.scroll_to_item(IndexPath::new(row), ScrollStrategy::Top, window, cx);
+                state.scroll_to_item(row, ScrollStrategy::Top, window, cx);
             });
         }
     }
@@ -2474,7 +2646,7 @@ impl Workbench {
         let show_titlebar = cfg!(target_os = "macos")
             || matches!(window.window_decorations(), Decorations::Client { .. });
         v_flex()
-            .w(px(224.))
+            .w(SIDEBAR_W)
             .h_full()
             .flex_shrink_0()
             .bg(theme.sidebar)
@@ -2727,18 +2899,6 @@ impl Workbench {
     fn render_session_list(&self, cx: &Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let shown = self.list_state.read(cx).delegate().sessions.len();
-        let library_empty = self.agent_counts.iter().map(|(_, n)| *n).sum::<i64>() == 0;
-        let listed_count = self.total_sessions.max(0);
-        let shown_label: SharedString = format!(
-            "{} {}",
-            listed_count,
-            if listed_count == 1 {
-                "session"
-            } else {
-                "sessions"
-            }
-        )
-        .into();
         let sort_key = self.sort_key;
         let sort_ascending = self.sort_ascending;
         let sort_entity = cx.entity();
@@ -2757,6 +2917,7 @@ impl Workbench {
             }
         );
         // 与详情工具栏统一：icon-only ghost，常态透明、hover 才出现背景。
+        // 当前排序方式由 tooltip 给出
         let sort_menu = Button::new("sort-sessions")
             .ghost()
             .rounded(RADIUS_BUTTON)
@@ -2794,8 +2955,10 @@ impl Workbench {
                     .item(mk_dir("Ascending", true))
             })
             .anchor(Corner::TopRight);
+        // 被 limit 截断时要说出来,否则侧栏计数与列表长度互相矛盾
+        let truncated = self.total_sessions > shown as i64;
         v_flex()
-            .w(px(336.))
+            .w(STREAM_W)
             .h_full()
             .flex_shrink_0()
             .bg(theme.list)
@@ -2803,107 +2966,123 @@ impl Workbench {
                 v_flex()
                     .id("list-header")
                     .w_full()
-                    .h(LIBRARY_IDENTITY_HEIGHT)
                     .flex_shrink_0()
                     .window_control_area(WindowControlArea::Drag)
                     .px(SPACE_LG)
-                    .justify_center()
+                    // 与详情头同一个顶部偏移:两栏标题因此等高。不用固定高度
+                    // 居中——中栏只有标题一行、详情有标题+元信息两行,居中之下
+                    // 两者必然错开,且「标题对齐」与「组头对齐元信息」不可兼得
+                    .pt(SPACE_XL)
+                    // 首组与标题的距离 = 这里 + 组头 pt。加在这一侧而不是组头上:
+                    // 组头 pt 同时管着组间距,且对所有组头必须一致
+                    .pb(SPACE_SM)
                     .child(
                         h_flex()
                             .w_full()
                             .items_start()
                             .justify_between()
+                            .gap(SPACE_SM)
                             .child(
-                                v_flex()
+                                // 角标是带内边距的胶囊,baseline 对齐会坐低半档
+                                h_flex()
                                     .min_w_0()
-                                    .gap(px(2.))
+                                    .items_center()
+                                    .gap(SPACE_SM)
                                     .child(
                                         div()
+                                            .min_w_0()
                                             .truncate()
                                             .text_size(FONT_TITLE)
                                             .font_semibold()
                                             .child(self.context_title()),
                                     )
-                                    .child(
-                                        div()
-                                            .text_size(FONT_LABEL)
-                                            .text_color(theme.muted_foreground)
-                                            .child(shown_label),
-                                    ),
+                                    .when(self.total_sessions > 0, |this| {
+                                        this.child(
+                                            div().flex_shrink_0().text_size(FONT_LABEL).child(
+                                                badge(
+                                                    self.total_sessions.to_string(),
+                                                    theme.muted,
+                                                    theme.muted_foreground,
+                                                ),
+                                            ),
+                                        )
+                                    }),
                             )
                             .child(div().flex_shrink_0().pt(px(2.)).child(sort_menu)),
                     ),
             )
             .child(if shown == 0 {
-                if library_empty && self.scan.scanning {
-                    v_flex()
-                        .flex_1()
-                        .w_full()
-                        .items_center()
-                        .justify_center()
-                        .gap(SPACE_MD)
-                        .text_color(theme.muted_foreground)
-                        .child(Spinner::new())
-                        .child(
-                            div()
-                                .text_size(FONT_BODY)
-                                .font_medium()
-                                .text_color(theme.foreground)
-                                .child("Building your library"),
-                        )
-                        .child(
-                            div()
-                                .text_size(FONT_CAPTION)
-                                .child("Looking for local agent sessions…"),
-                        )
-                        .into_any_element()
-                } else if library_empty {
-                    v_flex()
-                        .flex_1()
-                        .w_full()
-                        .items_center()
-                        .justify_center()
-                        .gap(SPACE_LG)
-                        .child(empty_state(
-                            "icons/layers.svg",
+                v_flex()
+                    .flex_1()
+                    .justify_center()
+                    // 首次全量扫描期间列表本来就是空的,不能报"没有匹配项"
+                    .child(if self.scan.scanning {
+                        empty_state(
+                            "icons/loader-circle.svg",
                             px(48.),
                             px(22.),
-                            "Your library is empty",
-                            "Add a local session location to get started.",
+                            "Indexing your sessions",
+                            match self.scan.total {
+                                0 => "Looking for session files…".to_string(),
+                                total => format!("{} of {total} sessions", self.scan.done),
+                            },
                             cx,
-                        ))
-                        .child(
-                            Button::new("empty-open-settings")
-                                .primary()
-                                .small()
-                                .rounded(RADIUS_BUTTON)
-                                .label("Add a location")
-                                .on_click(cx.listener(|this, _, _window, cx| {
-                                    this.settings_page = SettingsPage::Locations;
-                                    this.open_settings(cx);
-                                })),
                         )
-                        .into_any_element()
-                } else {
-                    v_flex()
-                        .flex_1()
-                        .w_full()
-                        .justify_center()
-                        .child(empty_state(
+                    } else if let Some(err) = self.scan.error.clone() {
+                        empty_state(
+                            "icons/circle-x.svg",
+                            px(48.),
+                            px(22.),
+                            "Couldn't index your sessions",
+                            err,
+                            cx,
+                        )
+                    } else if self.favorite_only
+                        || self.selected_agent.is_some()
+                        || self.selected_project.is_some()
+                    {
+                        empty_state(
                             "icons/inbox.svg",
                             px(48.),
                             px(22.),
-                            "No matching sessions",
-                            "Try a different agent, project, or filter.",
+                            "No sessions here",
+                            "Pick All Sessions in the sidebar to see everything.",
                             cx,
-                        ))
-                        .into_any_element()
-                }
+                        )
+                    } else {
+                        empty_state(
+                            "icons/inbox.svg",
+                            px(48.),
+                            px(22.),
+                            "No sessions yet",
+                            "Wake found no agent sessions on this Mac.",
+                            cx,
+                        )
+                    })
+                    .into_any_element()
             } else {
-                List::new(&self.list_state)
+                v_flex()
                     .flex_1()
                     .min_h_0()
-                    .w_full()
+                    .child(List::new(&self.list_state).flex_1().min_h_0())
+                    .when(truncated, |this| {
+                        this.child(
+                            div()
+                                .flex_shrink_0()
+                                .w_full()
+                                .px(SPACE_LG)
+                                .py(SPACE_SM)
+                                .border_t_1()
+                                .border_color(theme.border)
+                                .text_size(FONT_LABEL)
+                                .text_color(theme.muted_foreground)
+                                .truncate()
+                                .child(format!(
+                                    "Showing the {shown} most recent of {} sessions",
+                                    self.total_sessions
+                                )),
+                        )
+                    })
                     .into_any_element()
             })
     }
@@ -2918,9 +3097,14 @@ impl Workbench {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        // 窄窗口下阅读区不足 PROSE_MAX_W,工具卡参数格数要跟着收
+        let prose_w =
+            (window.viewport_size().width - SIDEBAR_W - STREAM_W - SPACE_MD * 2. - px(20.))
+                .clamp(px(220.), PROSE_MAX_W);
+        // 减去卡片内边距 26 + chevron 11 + gap 14 + 名称与徽标约 100
+        let tool_arg_cells = cells_for((prose_w - px(151.)).max(px(80.)), CELL_PX_MONO);
         let theme = cx.theme();
         let dark = theme.mode.is_dark();
-        let muted_fg = theme.muted_foreground;
         // 尾部要用的 Copy 值提前取出,theme 借用不跨越 inner 构建期的 &mut cx
         let jump_bg = theme.primary.opacity(0.09);
         let jump_radius = theme.radius;
@@ -2928,7 +3112,8 @@ impl Workbench {
             return div().into_any_element();
         };
         let total = detail.transcript.len();
-        let expanded = detail.expanded_rows.contains(&ix);
+        let tools_open = detail.expanded_tools.contains(&ix);
+        let think_open = detail.expanded_thinking.contains(&ix);
         let jump_seq = detail.jump_seq;
         // Rc 克隆只加引用计数;逐行借用,避免每帧深拷贝整条消息(text 可达 32KB)
         let transcript = detail.transcript.clone();
@@ -2951,79 +3136,75 @@ impl Workbench {
             centered_pill("Context compacted", cx).into_any_element()
         } else {
             match m.role {
+                // 角色靠形态区分:用户右对齐气泡,助手全宽平铺,不加文字标签
                 Role::User => h_flex()
                     .w_full()
                     .justify_end()
                     .child(
                         div()
-                            .max_w(px(540.))
+                            .max_w(BUBBLE_MAX_W)
                             .min_w_0()
-                            .rounded(theme.radius_lg)
-                            .bg(theme.muted)
-                            .px(px(14.))
-                            .py(SPACE_SM)
+                            .rounded(RADIUS_BUBBLE)
+                            .bg(crate::theme::bubble_bg(dark))
+                            .px(px(17.))
+                            .py(px(11.))
                             .text_size(FONT_MSG_USER)
-                            .child(
-                                TextView::markdown(
-                                    SharedString::from(format!("dmsg-{}", m.seq)),
-                                    m.text.clone(),
-                                    window,
-                                    cx,
-                                )
-                                .style(TextViewStyle {
-                                    heading_base_font_size: FONT_MSG_USER,
-                                    paragraph_gap: gpui::rems(0.5),
-                                    is_dark: dark,
-                                    ..Default::default()
-                                })
-                                .line_height(relative(1.45))
-                                .selectable(true),
-                            ),
+                            .line_height(relative(LINE_HEIGHT_BUBBLE))
+                            .child(markdown_body(
+                                format!("dmsg-{}", m.seq).into(),
+                                m.text.clone(),
+                                FONT_MSG_USER,
+                                dark,
+                                window,
+                                cx,
+                            )),
                     )
                     .into_any_element(),
                 Role::Assistant => {
-                    let mut col = v_flex().w_full().min_w_0().gap(SPACE_SM);
-                    if !m.text.is_empty() {
-                        if let Some(th) = &m.thinking {
-                            col = col.child(
-                                div()
-                                    .text_size(FONT_MSG_THINKING)
-                                    .italic()
-                                    .text_color(muted_fg)
-                                    .truncate()
-                                    .child(format!("Thinking · {}", one_line(th, 200))),
-                            );
-                        }
+                    // thinking 卡 / 正文 / 工具卡之间的呼吸
+                    let mut col = v_flex().w_full().min_w_0().gap(px(12.));
+                    if let Some(th) = &m.thinking {
+                        col = col.child(think_panel(
+                            ix,
+                            th,
+                            think_open,
+                            cx.listener(move |this, _, _window, cx| {
+                                if let Some(detail) = &mut this.detail {
+                                    if !detail.expanded_thinking.insert(ix) {
+                                        detail.expanded_thinking.remove(&ix);
+                                    }
+                                    detail.msg_list.splice(ix..ix + 1, 1);
+                                }
+                                cx.notify();
+                            }),
+                            cx,
+                        ));
                     }
                     if !m.text.is_empty() {
                         col = col.child(
-                            div().text_size(FONT_MSG_BODY).child(
-                                TextView::markdown(
-                                    SharedString::from(format!("dmsg-{}", m.seq)),
-                                    m.text.clone(),
+                            div()
+                                .text_size(FONT_MSG_BODY)
+                                .line_height(relative(LINE_HEIGHT_PROSE))
+                                .child(markdown_message(
+                                    m.seq,
+                                    &m.text,
+                                    FONT_MSG_BODY,
+                                    dark,
                                     window,
                                     cx,
-                                )
-                                .style(TextViewStyle {
-                                    heading_base_font_size: FONT_MSG_BODY,
-                                    paragraph_gap: gpui::rems(0.6),
-                                    is_dark: dark,
-                                    ..Default::default()
-                                })
-                                .line_height(relative(1.5))
-                                .selectable(true),
-                            ),
+                                )),
                         );
                     }
                     if !m.tool_calls.is_empty() {
                         col = col.child(tool_cluster(
                             ix,
                             &m.tool_calls,
-                            expanded,
+                            tool_arg_cells,
+                            tools_open,
                             cx.listener(move |this, _, _window, cx| {
                                 if let Some(detail) = &mut this.detail {
-                                    if !detail.expanded_rows.insert(ix) {
-                                        detail.expanded_rows.remove(&ix);
+                                    if !detail.expanded_tools.insert(ix) {
+                                        detail.expanded_tools.remove(&ix);
                                     }
                                     // 行高随展开变化,让 list 重测该行
                                     detail.msg_list.splice(ix..ix + 1, 1);
@@ -3043,15 +3224,14 @@ impl Workbench {
             .w_full()
             .flex()
             .justify_center()
-            // 与详情头共用 24px 阅读轴，正文、标题和元信息形成一条竖线。
-            .px(SPACE_XXL)
-            .py(SPACE_SM)
-            .when(ix == 0, |d| d.pt(SPACE_LG))
+            .px(px(10.))
+            .py(px(15.))
+            .when(ix == 0, |d| d.pt(SPACE_XXL))
             .when(ix + 1 == total, |d| d.pb(SPACE_XXL))
             .child(
                 div()
                     .w_full()
-                    .max_w(px(720.))
+                    .max_w(PROSE_MAX_W)
                     .min_w_0()
                     // 淡 primary 底:标记搜索命中落点(尾部命中不滚动,全靠它识别)。
                     // 负 margin + 等量 padding:背景向外扩出呼吸边,内容原位不推挤,
@@ -3152,7 +3332,7 @@ impl Workbench {
                 .gap(px(2.))
                 .child(
                     div()
-                        .text_size(FONT_TITLE)
+                        .text_size(FONT_DISPLAY)
                         .font_semibold()
                         .text_color(theme.foreground)
                         .child(value),
@@ -3167,7 +3347,7 @@ impl Workbench {
         // 序:Sessions / Tokens / Prompts / Agents / Projects / Active days
         // (用户钉的)
         let overview = h_flex()
-            .gap(px(40.))
+            .gap(SPACE_XXL)
             .child(stat(thousands(d.sessions), "Sessions"))
             .when(d.tokens > 0, |row| {
                 row.child(stat(fmt_tokens(Some(d.tokens)), "Tokens"))
@@ -3367,7 +3547,7 @@ impl Workbench {
             .into_any_element()
     }
 
-    fn render_detail(&self, _window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+    fn render_detail(&self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         let theme = cx.theme();
         let Some(detail) = &self.detail else {
             return v_flex()
@@ -3390,6 +3570,13 @@ impl Workbench {
                 .into_any_element();
         };
         let meta = &detail.meta;
+        // 窗口宽 − 侧栏 − 会话流 − 头部内边距 − 操作区,每帧重算
+        let title_w = (window.viewport_size().width
+            - SIDEBAR_W
+            - STREAM_W
+            - SPACE_LG * 2.
+            - DETAIL_ACTIONS_W)
+            .max(px(140.));
         let session_id = meta.id.clone();
         let export_entity = cx.entity();
         let reveal_entity = export_entity.clone();
@@ -3446,12 +3633,6 @@ impl Workbench {
             })
             .anchor(Corner::TopRight);
 
-        let detail_path: SharedString = if meta.project_path.is_empty() {
-            "Unknown project".to_string()
-        } else {
-            meta.project_path.clone()
-        }
-        .into();
         let mut detail_facts: Vec<String> = Vec::new();
         if meta.message_count > 0 {
             detail_facts.push(format!("{} messages", meta.message_count));
@@ -3459,20 +3640,6 @@ impl Workbench {
         if let Some(tokens) = meta.tokens_used {
             detail_facts.push(format!("{} tokens", fmt_tokens(Some(tokens))));
         }
-        let has_detail_facts = !detail_facts.is_empty();
-        let detail_fact_line: SharedString = detail_facts.join(" · ").into();
-        let created_time: Option<(SharedString, SharedString)> = (meta.created_at > 0).then(|| {
-            (
-                format!("Created {}", smart_time(meta.created_at)).into(),
-                format!("Created {}", abs_date(meta.created_at)).into(),
-            )
-        });
-        let updated_time: Option<(SharedString, SharedString)> = (meta.updated_at > 0).then(|| {
-            (
-                format!("Updated {}", smart_time(meta.updated_at)).into(),
-                format!("Updated {}", abs_date(meta.updated_at)).into(),
-            )
-        });
 
         v_flex()
             .flex_1()
@@ -3482,40 +3649,43 @@ impl Workbench {
             .child(
                 v_flex()
                     .id("detail-header")
+                    .w_full()
                     .flex_shrink_0()
                     .window_control_area(WindowControlArea::Drag)
-                    .px(SPACE_XXL)
-                    .pb(SPACE_SM)
-                    .border_b_1()
-                    .border_color(theme.border)
+                    .px(SPACE_LG)
+                    .pt(SPACE_XL)
+                    .pb(SPACE_MD)
+                    // 两层:标题行(含操作区)+ 单条元信息带。gap 与会话流「header
+                    // 的 pb + 组头 pt」等值,首组组头因此与这条元信息带齐平
+                    .gap(SPACE_LG)
                     .child(
                         h_flex()
-                            .w_full()
-                            .h(WINDOW_TITLEBAR_HEIGHT)
+                            .gap(SPACE_LG)
                             .items_center()
-                            .justify_between()
-                            .gap(SPACE_MD)
                             .child(
-                                h_flex()
-                                    .flex_1()
-                                    .min_w_0()
-                                    .gap(SPACE_SM)
-                                    .items_center()
-                                    .text_size(FONT_LABEL)
-                                    .text_color(theme.muted_foreground)
-                                    .child(img(meta.agent.brand_icon(theme.mode.is_dark())).size(px(15.)).flex_shrink_0())
-                                    .child(div().flex_shrink_0().child(meta.agent.display_name()))
-                                    .child(badge(meta.project_name.clone(), theme.muted, theme.muted_foreground))
-                                    .when_some(meta.git_branch.clone(), |this, branch| {
-                                        this.child(
-                                            h_flex()
-                                                .min_w_0()
-                                                .gap(SPACE_XS)
-                                                .child(icon("icons/git-branch.svg").with_size(px(11.)).flex_shrink_0())
-                                                .child(div().min_w_0().truncate().child(branch)),
-                                        )
-                                    }),
+                                // 单行截断。格数由 title_w 反算而非写死,否则
+                                // 拖拽窗口变宽后截断长度不会补齐;全文进 tooltip
+                                div()
+                                    .id("detail-title")
+                                    .w(title_w)
+                                    .flex_shrink_0()
+                                    .overflow_hidden()
+                                    .whitespace_nowrap()
+                                    .text_size(FONT_TITLE)
+                                    .font_semibold()
+                                    .tooltip({
+                                        let full: SharedString = meta.title.clone().into();
+                                        move |window, cx| {
+                                            gpui_component::tooltip::Tooltip::new(full.clone())
+                                                .build(window, cx)
+                                        }
+                                    })
+                                    .child(clip_display(
+                                        &meta.title,
+                                        cells_for(title_w, CELL_PX_TITLE),
+                                    )),
                             )
+                            .child(div().flex_1().min_w_0())
                             .child(
                                 h_flex()
                                     .flex_shrink_0()
@@ -3683,141 +3853,126 @@ impl Workbench {
                                     .child(more_menu),
                             ),
                     )
-                    .child(
+                    .child({
+                        // 单条元信息带:身份 · 位置 · 规模 · 时间,同字号同色。
+                        // 完整项目路径与精确时间进 tooltip;JSONL 文件路径不再
+                        // 占位(中段是 UUID,Reveal 入口在 `…` 菜单里)
+                        let mut stats: Vec<String> = Vec::new();
+                        if meta.message_count > 0 {
+                            stats.push(format!("{} messages", meta.message_count));
+                        }
+                        if let Some(tokens) = meta.tokens_used {
+                            stats.push(format!("{} tokens", fmt_tokens(Some(tokens))));
+                        }
+                        if meta.updated_at > 0 {
+                            stats.push(format!("Updated {}", relative_time(meta.updated_at)));
+                        }
+                        let exact_time: SharedString = {
+                            let mut parts: Vec<String> = Vec::new();
+                            if meta.created_at > 0 {
+                                parts.push(format!("Created {}", abs_date(meta.created_at)));
+                            }
+                            if meta.updated_at > 0 {
+                                parts.push(format!("Updated {}", abs_date(meta.updated_at)));
+                            }
+                            parts.join("\n").into()
+                        };
+                        let project_path: SharedString = if meta.project_path.is_empty() {
+                            "Unknown project".into()
+                        } else {
+                            meta.project_path.clone().into()
+                        };
+                        let reveal_path = meta.file_path.clone();
                         h_flex()
-                            .w_full()
-                            .h(WINDOW_TITLEBAR_HEIGHT)
-                            .min_w_0()
+                            .flex_wrap()
+                            .gap(px(7.))
                             .items_center()
-                            .child(
-                                div()
-                                    .min_w_0()
-                                    .truncate()
-                                    .text_size(FONT_TITLE)
-                                    .line_height(relative(1.15))
-                                    .font_semibold()
-                                    .child(meta.title.clone()),
-                            ),
-                    )
-                    .child(
-                        v_flex()
-                            .w_full()
-                            .min_w_0()
-                            .pt(SPACE_SM)
-                            .gap(SPACE_SM)
                             .text_size(FONT_LABEL)
                             .text_color(theme.muted_foreground)
                             .child(
-                                h_flex()
-                                    .w_full()
-                                    .min_w_0()
-                                    .gap(SPACE_MD)
-                                    .items_center()
-                                    .when_some(meta.model.clone(), |this, model| {
-                                        this.child(outline_badge(
-                                            model,
-                                            rgb(crate::theme::MODEL_BADGE_BG).into(),
-                                        ))
-                                    })
-                                    .when_some(
-                                        meta.source.clone().filter(|s| !s.is_empty()),
-                                        |this, source| {
-                                            let color = if source == "opencode2" {
-                                                theme.primary
-                                            } else {
-                                                theme.success
-                                            };
-                                            this.child(outline_badge(source, color))
-                                        },
-                                    )
-                                    .when(has_detail_facts, |this| {
-                                        this.child(
-                                            div()
-                                                .flex_1()
-                                                .min_w_0()
-                                                .truncate()
-                                                .child(detail_fact_line),
-                                        )
-                                    }),
+                                img(meta.agent.brand_icon(theme.mode.is_dark()))
+                                    .size(px(13.))
+                                    .flex_shrink_0(),
                             )
+                            .child(div().flex_shrink_0().child(meta.agent.display_name()))
+                            .child(meta_sep(theme.muted_foreground))
+                            // hover 看全路径,点击 Reveal
                             .child(
-                                h_flex()
+                                div()
+                                    .id("detail-project")
                                     .min_w_0()
-                                    .gap(px(6.))
-                                    .child(
-                                        icon("icons/folder.svg")
-                                            .with_size(px(12.))
-                                            .flex_shrink_0(),
-                                    )
-                                    .child(div().min_w_0().truncate().child(detail_path)),
-                            )
-                            .when(created_time.is_some() || updated_time.is_some(), |this| {
-                                this.child(
-                                    h_flex()
-                                        .w_full()
-                                        .min_w_0()
-                                        .gap(px(6.))
-                                        .items_center()
-                                        .child(
-                                            icon("icons/calendar.svg")
-                                                .with_size(px(12.))
-                                                .flex_shrink_0(),
+                                    .truncate()
+                                    .cursor_pointer()
+                                    .hover(|s| s.text_colored(theme.foreground, FONT_LABEL))
+                                    .tooltip(move |window, cx| {
+                                        gpui_component::tooltip::Tooltip::new(
+                                            project_path.clone(),
                                         )
-                                        .child(
-                                            h_flex()
-                                                .min_w_0()
-                                                .gap(SPACE_MD)
-                                                .when_some(
-                                                    created_time.clone(),
-                                                    |row, (created, tooltip)| {
-                                                        row.child(
-                                                            div()
-                                                                .id("detail-created-time")
-                                                                .min_w_0()
-                                                                .truncate()
-                                                                .child(created)
-                                                                .tooltip(move |window, cx| {
-                                                                    gpui_component::tooltip::Tooltip::new(
-                                                                        tooltip.clone(),
-                                                                    )
-                                                                    .build(window, cx)
-                                                                }),
-                                                        )
-                                                    },
+                                        .build(window, cx)
+                                    })
+                                    .on_click(move |_, _, _| {
+                                        terminal::reveal_in_file_manager(&reveal_path);
+                                    })
+                                    .child(clip_display(&meta.project_name, 34)),
+                            )
+                            // detached HEAD 下透传的 "HEAD" 对用户零信息量
+                            .when_some(
+                                meta.git_branch.clone().filter(|b| {
+                                    let b = b.trim();
+                                    !b.is_empty() && b != "HEAD" && b != "detached"
+                                }),
+                                |this, branch| {
+                                    this.child(meta_sep(theme.muted_foreground)).child(
+                                        h_flex()
+                                            .min_w_0()
+                                            .gap(SPACE_XS)
+                                            .child(
+                                                icon("icons/git-branch.svg")
+                                                    .with_size(px(11.))
+                                                    .flex_shrink_0(),
+                                            )
+                                            .child(div().min_w_0().truncate().child(branch)),
+                                    )
+                                },
+                            )
+                            // model 用同级 muted 文字而非徽标:品牌色只表达
+                            // agent 身份,不该套在所有 agent 的 model 上
+                            .when_some(meta.model.clone(), |this, model| {
+                                this.child(meta_sep(theme.muted_foreground))
+                                    .child(div().flex_shrink_0().child(model))
+                            })
+                            // source 是枚举值不是自由文本,做成徽标才读得出
+                            .when_some(
+                                meta.source.clone().filter(|s| !s.is_empty()),
+                                |this, source| {
+                                    // opencode2 是版本代际标记而非发起平台,
+                                    // 用 primary 蓝与 via 徽章(绿)区分
+                                    let color = if source == "opencode2" {
+                                        theme.primary
+                                    } else {
+                                        theme.success
+                                    };
+                                    this.child(outline_badge(source, color))
+                                },
+                            )
+                            .when(!stats.is_empty(), |this| {
+                                this.child(meta_sep(theme.muted_foreground)).child(
+                                    div()
+                                        .id("detail-stats")
+                                        .min_w_0()
+                                        .truncate()
+                                        .when(!exact_time.is_empty(), |el| {
+                                            el.tooltip(move |window, cx| {
+                                                gpui_component::tooltip::Tooltip::new(
+                                                    exact_time.clone(),
                                                 )
-                                                .when(
-                                                    created_time.is_some()
-                                                        && updated_time.is_some(),
-                                                    |row| {
-                                                        row.child(
-                                                            div()
-                                                                .flex_shrink_0()
-                                                                .text_color(theme.border)
-                                                                .child("·"),
-                                                        )
-                                                    },
-                                                )
-                                                .when_some(
-                                                    updated_time.clone(),
-                                                    |row, (updated, tooltip)| {
-                                                        row.child(
-                                                            div()
-                                                                .id("detail-updated-time")
-                                                                .flex_shrink_0()
-                                                                .child(updated)
-                                                                .tooltip(move |window, cx| {
-                                                                    gpui_component::tooltip::Tooltip::new(
-                                                                        tooltip.clone(),
-                                                                    )
-                                                                    .build(window, cx)
-                                                                }),
-                                                        )
-                                                    },
-                                                ),
-                                        ),
+                                                .build(window, cx)
+                                            })
+                                        })
+                                        .child(stats.join(" · ")),
                                 )
-                            }),
-                    ),
+                            })
+                    }),
             )
             .child(if detail.loading {
                 h_flex()
@@ -3830,14 +3985,58 @@ impl Workbench {
                     .child(Spinner::new().small())
                     .child(div().text_size(FONT_BODY).child("Loading session…"))
                     .into_any_element()
+            } else if let Some(reason) = detail.error.clone() {
+                let reveal_path = detail.meta.file_path.clone();
+                v_flex()
+                    .flex_1()
+                    .min_h_0()
+                    .items_center()
+                    .justify_center()
+                    .px(SPACE_MD)
+                    .pb(SPACE_MD)
+                    .child(
+                        v_flex()
+                            .w(px(380.))
+                            .p(SPACE_XXL)
+                            .gap(SPACE_MD)
+                            .items_center()
+                            .rounded(theme.radius_lg)
+                            .bg(theme.popover)
+                            .child(empty_state(
+                                "icons/circle-x.svg",
+                                px(58.),
+                                px(26.),
+                                "Couldn't open this session",
+                                reason,
+                                cx,
+                            ))
+                            .child(
+                                Button::new("detail-error-reveal")
+                                    .outline()
+                                    .small()
+                                    .rounded(RADIUS_BUTTON)
+                                    .icon(icon("icons/folder.svg").with_size(px(13.)))
+                                    .label(REVEAL_IN_FM)
+                                    .on_click(move |_, _, _| {
+                                        terminal::reveal_in_file_manager(&reveal_path);
+                                    }),
+                            ),
+                    )
+                    .into_any_element()
             } else {
                 let entity = cx.entity().downgrade();
                 div()
                     .flex_1()
                     .min_h_0()
-                    .bg(theme.popover)
-                    .relative()
+                    .px(SPACE_MD)
+                    .pb(SPACE_MD)
                     .child(
+                        div()
+                            .size_full()
+                            .rounded(theme.radius_lg)
+                            .bg(theme.popover)
+                            .relative()
+                            .child(
                         gpui::list(detail.msg_list.clone(), move |ix, window, cx| {
                             entity
                                 .upgrade()
@@ -3846,9 +4045,10 @@ impl Workbench {
                                 })
                                 .unwrap_or_else(|| div().into_any_element())
                         })
-                        .size_full(),
+                                .size_full(),
+                            )
+                            .vertical_scrollbar(&detail.msg_list),
                     )
-                    .vertical_scrollbar(&detail.msg_list)
                     .into_any_element()
             })
             .into_any_element()
@@ -4010,7 +4210,7 @@ fn usage_bar_row(
     let theme = cx.theme();
     let frac = (count as f32 / max.max(1) as f32).clamp(0., 1.);
     h_flex()
-        .h(px(22.))
+        .h(SPACE_XXL)
         .gap(SPACE_SM)
         .items_center()
         .when_some(lead, |row, lead| {
@@ -4172,7 +4372,7 @@ fn render_distribution(range: InsightsRange, values: &[i64], peak: usize, cx: &A
                         .id(("dist", i))
                         .flex_1()
                         .h(height)
-                        .rounded(px(2.))
+                        .rounded(RADIUS_CELL)
                         .bg(bg)
                         .tooltip(move |window, cx| {
                             gpui_component::tooltip::Tooltip::new(label.clone()).build(window, cx)
@@ -4296,7 +4496,7 @@ fn render_heatmap(d: &InsightsData, cx: &App) -> AnyElement {
                 div()
                     .id(("hm", ix))
                     .size(px(CELL))
-                    .rounded(px(2.))
+                    .rounded(RADIUS_CELL)
                     .bg(heat_color(n))
                     // 只捕获 Copy 的 (start, ix, n),hover 到的那格才格式化
                     .tooltip(move |window, cx| {
@@ -4338,7 +4538,7 @@ fn render_heatmap(d: &InsightsData, cx: &App) -> AnyElement {
                 .flex_shrink_0()
                 .child("Less")
                 .children(std::iter::once(0.).chain(HEAT).map(|a: f32| {
-                    div().size(px(CELL)).rounded(px(2.)).bg(if a == 0. {
+                    div().size(px(CELL)).rounded(RADIUS_CELL).bg(if a == 0. {
                         theme.muted
                     } else {
                         theme.primary.opacity(a)
@@ -4416,6 +4616,265 @@ fn empty_state(
         .child(div().text_size(FONT_CAPTION).child(caption.into()))
 }
 
+/// markdown 里的一个块:ATX 标题单独切出来,其余内容整段留给 TextView。
+///
+/// 组件的标题渲染只有 `pb`、没有 `pt`(`Node::Heading`),标题上方的间距
+/// 等同于普通段距,层级读不出来;`TextViewStyle` 也无对应钩子。切出来后
+/// 上间距由外层 div 给。
+///
+/// 代价:一条消息拆成多个 TextView,跨块的文字选择会断在块边界。
+struct MdBlock {
+    /// Some(级别) = ATX 标题;None = 普通内容块
+    heading: Option<u8>,
+    text: String,
+}
+
+/// `#` 到 `######` 后面**跟空格**才是 ATX 标题;`#hashtag` 不是
+fn atx_level(line: &str) -> Option<u8> {
+    let hashes = line.bytes().take_while(|b| *b == b'#').count();
+    if hashes == 0 || hashes > 6 {
+        return None;
+    }
+    match line.as_bytes().get(hashes) {
+        Some(b' ') => Some(hashes as u8),
+        _ => None,
+    }
+}
+
+fn split_markdown_blocks(src: &str) -> Vec<MdBlock> {
+    let mut out: Vec<MdBlock> = Vec::new();
+    let mut buf = String::new();
+    // 围栏代码块里的 `# ` 是注释不是标题,必须跟踪开合状态
+    let mut fence: Option<String> = None;
+
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        if let Some(marker) = &fence {
+            if trimmed.starts_with(marker.as_str()) {
+                fence = None;
+            }
+        } else if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            fence = Some(trimmed[..3].to_string());
+        }
+
+        match fence.is_none().then(|| atx_level(trimmed)).flatten() {
+            Some(level) => {
+                if !buf.trim().is_empty() {
+                    out.push(MdBlock {
+                        heading: None,
+                        text: std::mem::take(&mut buf),
+                    });
+                }
+                buf.clear();
+                out.push(MdBlock {
+                    heading: Some(level),
+                    text: line.to_string(),
+                });
+            }
+            None => {
+                buf.push_str(line);
+                buf.push('\n');
+            }
+        }
+    }
+    if !buf.trim().is_empty() {
+        out.push(MdBlock {
+            heading: None,
+            text: buf,
+        });
+    }
+    out
+}
+
+/// 标题与上文之间的间距,按层级递减。见 `MdBlock`。
+fn heading_top_gap(level: u8) -> Pixels {
+    match level {
+        1 => px(30.),
+        2 => px(25.),
+        3 => px(20.),
+        _ => px(16.),
+    }
+}
+
+/// 一条助手消息的正文:按标题切块后逐块渲染,标题块由外层 div 控制上下间距。
+fn markdown_message(
+    seq: i64,
+    text: &str,
+    base: Pixels,
+    dark: bool,
+    window: &mut Window,
+    cx: &mut App,
+) -> Div {
+    let blocks = split_markdown_blocks(text);
+    let mut col = v_flex().w_full().min_w_0();
+    for (ix, block) in blocks.into_iter().enumerate() {
+        let id: SharedString = format!("dmsg-{seq}-{ix}").into();
+        let body = markdown_body(id, block.text, base, dark, window, cx);
+        col = match block.heading {
+            // 消息以标题开头时不留上间距,否则会看起来与上一条消息断开
+            Some(level) => col.child(
+                div()
+                    .when(ix > 0, |el| el.pt(heading_top_gap(level)))
+                    .pb(px(3.))
+                    .child(body),
+            ),
+            None => col.child(body),
+        };
+    }
+    col
+}
+
+/// 对话正文的 markdown 视图,用户气泡与助手平铺共用。组件已内置 table /
+/// blockquote / divider / 标题分级 / tree-sitter 高亮,这里只做样式覆写。
+fn markdown_body(
+    id: SharedString,
+    text: String,
+    base: Pixels,
+    dark: bool,
+    window: &mut Window,
+    cx: &mut App,
+) -> TextView {
+    let code_bg = crate::theme::panel_bg(dark);
+    let code_border = crate::theme::panel_border(dark);
+    // id 必须带深浅模式。TextView 只在首次 request_layout 时同步解析,
+    // 之后 style 变化走异步通道(200ms debounce + 后台重解析),而语法高亮
+    // 的颜色是解析阶段固化进 `CodeBlock.styles` 的——不换 id 就要慢一拍
+    // 才变色。id 变则被视作新元素,走首次的同步解析路径。
+    let id: SharedString = format!("{id}-{}", if dark { "d" } else { "l" }).into();
+    TextView::markdown(id, text, window, cx)
+        .style(
+            TextViewStyle {
+                heading_base_font_size: base,
+                paragraph_gap: gpui::rems(PROSE_PARAGRAPH_GAP),
+                is_dark: dark,
+                // 必须显式给:默认值恒为 light;且 `TextViewStyle` 的
+                // PartialEq 只比较 paragraph_gap / heading_base_font_size /
+                // highlight_theme,不换它则深浅切换后 style 被判定相等、
+                // 组件不重建,代码块会留着上一个主题的配色
+                highlight_theme: if dark {
+                    HighlightTheme::default_dark().clone()
+                } else {
+                    HighlightTheme::default_light().clone()
+                },
+                ..Default::default()
+            }
+            // 对话里的标题不该有网页 h1 的体量(组件默认是正文的近两倍),
+            // 但差得太小又会混进正文
+            .heading_font_size(|level, base| match level {
+                1 => base * 1.45,
+                2 => base * 1.28,
+                3 => base * 1.14,
+                4 => base * 1.05,
+                _ => base,
+            })
+            .code_block(
+                StyleRefinement::default()
+                    .bg(code_bg)
+                    .border_1()
+                    .border_color(code_border)
+                    .rounded(RADIUS_PANEL)
+                    .px(px(15.))
+                    .py(px(13.)),
+            ),
+        )
+        // 组件把 actions 绝对定位在块内右上角,做不了横跨顶部的工具栏,
+        // 所以语言名与复制合成一个胶囊
+        .code_block_actions(|block, _window, cx| {
+            let theme = cx.theme();
+            let code = block.code();
+            h_flex()
+                .gap(SPACE_SM)
+                .items_center()
+                .px(px(6.))
+                .text_size(FONT_LABEL)
+                .text_color(theme.muted_foreground)
+                .when_some(block.lang(), |el, lang| el.child(div().child(lang)))
+                .child(
+                    div()
+                        .id("code-copy")
+                        .cursor_pointer()
+                        .rounded(RADIUS_BADGE)
+                        .child(icon("icons/copy.svg").with_size(px(12.)))
+                        .tooltip(|window, cx| {
+                            gpui_component::tooltip::Tooltip::new("Copy code").build(window, cx)
+                        })
+                        .on_click(move |_, _, cx| {
+                            cx.write_to_clipboard(ClipboardItem::new_string(code.to_string()));
+                        }),
+                )
+        })
+        .selectable(true)
+}
+
+/// thinking 折叠面板。收起时头行给一句摘要,展开是完整原文。
+fn think_panel(
+    ix: usize,
+    text: &str,
+    expanded: bool,
+    on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    cx: &App,
+) -> Div {
+    let theme = cx.theme();
+    let dark = theme.mode.is_dark();
+    let mut panel = v_flex()
+        .w_full()
+        .min_w_0()
+        .rounded(RADIUS_PANEL)
+        .bg(crate::theme::panel_bg(dark))
+        .border_1()
+        .border_color(crate::theme::panel_border(dark))
+        .child(
+            h_flex()
+                .id(("think", ix))
+                .w_full()
+                .min_w_0()
+                .px(px(13.))
+                .py(px(9.))
+                .gap(px(7.))
+                .items_center()
+                .cursor_pointer()
+                .text_size(FONT_MSG_THINKING)
+                .text_color(theme.muted_foreground)
+                .hover(|s| s.text_colored(theme.foreground, FONT_MSG_THINKING))
+                .child(
+                    icon("icons/chevron-right.svg")
+                        .with_size(px(11.))
+                        .flex_shrink_0()
+                        .when(expanded, |ic| {
+                            ic.rotate(gpui::Radians(std::f32::consts::FRAC_PI_2))
+                        }),
+                )
+                .child(div().flex_shrink_0().font_medium().child("Thinking"))
+                // 展开后正文就在下面,头行不再重复
+                .when(!expanded, |el| {
+                    el.child(
+                        div()
+                            .min_w_0()
+                            .truncate()
+                            .italic()
+                            .child(one_line(text, 160)),
+                    )
+                })
+                .on_click(on_toggle),
+        );
+    if expanded {
+        panel = panel.child(
+            div()
+                .w_full()
+                .min_w_0()
+                // 对齐头行文字起点:13 + 11(图标) + 7(gap)
+                .pl(px(31.))
+                .pr(px(13.))
+                .pb(px(13.))
+                .text_size(FONT_MSG_THINKING)
+                .line_height(relative(1.75))
+                .text_color(theme.muted_foreground)
+                .child(text.to_string()),
+        );
+    }
+    panel
+}
+
 /// 对话区居中小胶囊(System 消息 / Context compacted)
 fn centered_pill(text: impl Into<SharedString>, cx: &App) -> Div {
     let theme = cx.theme();
@@ -4433,120 +4892,230 @@ fn centered_pill(text: impl Into<SharedString>, cx: &App) -> Div {
     )
 }
 
-/// 工具调用折叠簇:头行(chevron + 名字序列 + 失败计数)默认收起,
-/// 展开为左竖线缩进列表;仅失败项内联输出(错误才是回顾重点)。
+/// 工具输入输出在折叠体里的展示上限。不用内嵌滚动:嵌套滚动区在虚拟
+/// 列表行里会抢滚轮。
+const TOOL_OUTPUT_LIMIT: usize = 600;
+
+/// 工具调用折叠卡。头行 = chevron + 名称 + 参数摘要 + 结果徽标,
+/// 展开后逐条给出输入与输出(成功的调用也给)。
 fn tool_cluster(
     ix: usize,
     calls: &[ToolCallView],
+    arg_cells: usize,
     expanded: bool,
     on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     cx: &App,
 ) -> Div {
     let theme = cx.theme();
+    let dark = theme.mode.is_dark();
+    let panel_border = crate::theme::panel_border(dark);
     let failed = calls.iter().filter(|c| c.is_error).count();
-    let names = calls
-        .iter()
-        .map(|c| c.name.as_str())
-        .collect::<Vec<_>>()
-        .join(" · ");
-    let head_label = if calls.len() == 1 {
-        names.clone()
-    } else {
-        format!("{} tools · {}", calls.len(), names)
-    };
     let mono = theme.mono_font_family.clone();
 
-    let mut cluster = v_flex().w_full().min_w_0().gap(px(4.)).child(
-        h_flex()
-            .id(("tool-cluster", ix))
-            .w_full()
-            .min_w_0()
-            .gap(px(6.))
-            .cursor_pointer()
-            .text_size(FONT_CAPTION)
-            .text_color(theme.muted_foreground)
-            .hover(|s| s.text_colored(theme.foreground, FONT_CAPTION))
-            .child(
-                icon("icons/chevron-right.svg")
-                    .with_size(px(11.))
-                    .flex_shrink_0()
-                    .when(expanded, |ic| {
-                        ic.rotate(gpui::Radians(std::f32::consts::FRAC_PI_2))
-                    }),
-            )
-            .child(div().min_w_0().truncate().font_medium().child(head_label))
-            .when(failed > 0, |this| {
-                this.child(
+    // 单条给"名称 + 参数";多条给数量与名字序列,参数留到展开后逐条看
+    let (head_name, head_arg) = if let [only] = calls {
+        (
+            only.name.clone(),
+            Some(clip_display(&only.input_preview, arg_cells)),
+        )
+    } else {
+        let names = calls
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect::<Vec<_>>()
+            .join(" · ");
+        (
+            format!("{} tool calls", calls.len()),
+            Some(clip_display(&names, arg_cells)),
+        )
+    };
+
+    let mut cluster = v_flex()
+        .w_full()
+        .min_w_0()
+        .rounded(RADIUS_PANEL)
+        .bg(crate::theme::panel_bg(dark))
+        .border_1()
+        .border_color(panel_border)
+        .child(
+            h_flex()
+                .id(("tool-cluster", ix))
+                .w_full()
+                .min_w_0()
+                .px(px(13.))
+                .py(px(9.))
+                .gap(px(7.))
+                .items_center()
+                .cursor_pointer()
+                .text_size(FONT_MSG_THINKING)
+                .text_color(theme.muted_foreground)
+                .hover(|s| s.text_colored(theme.foreground, FONT_MSG_THINKING))
+                .child(
+                    icon("icons/chevron-right.svg")
+                        .with_size(px(11.))
+                        .flex_shrink_0()
+                        .when(expanded, |ic| {
+                            ic.rotate(gpui::Radians(std::f32::consts::FRAC_PI_2))
+                        }),
+                )
+                .child(
                     div()
                         .flex_shrink_0()
-                        .text_color(theme.danger)
-                        .child(format!("{failed} failed")),
+                        .font_medium()
+                        .text_color(theme.foreground)
+                        .child(head_name),
                 )
-            })
-            .on_click(on_toggle),
-    );
+                .when_some(head_arg, |el, arg| {
+                    el.child(
+                        div()
+                            .min_w_0()
+                            .overflow_hidden()
+                            .whitespace_nowrap()
+                            .font_family(mono.clone())
+                            .text_size(FONT_MSG_MONO)
+                            .child(arg),
+                    )
+                })
+                // 结果徽标常驻,不展开也知道有没有失败
+                .child(div().flex_1())
+                .when(failed > 0, |this| {
+                    this.child(
+                        div()
+                            .flex_shrink_0()
+                            .px(px(7.))
+                            .rounded(RADIUS_BADGE)
+                            .text_size(FONT_LABEL)
+                            .text_color(theme.danger)
+                            .bg(theme.danger.opacity(0.12))
+                            .child(format!("{failed} failed")),
+                    )
+                })
+                .on_click(on_toggle),
+        );
+
     if expanded {
         let mut items = v_flex()
             .w_full()
             .min_w_0()
-            .ml(px(5.))
-            .pl(px(12.))
-            .border_l_1()
-            .border_color(theme.border)
-            .gap(px(6.));
-        for tc in calls {
-            let mut item = v_flex().w_full().min_w_0().gap(px(2.)).child(
-                h_flex()
-                    .w_full()
-                    .min_w_0()
-                    .gap(px(6.))
-                    .child(
-                        div()
-                            .flex_shrink_0()
-                            .text_size(FONT_CAPTION)
-                            .font_medium()
-                            .text_color(if tc.is_error {
-                                theme.danger
-                            } else {
-                                theme.foreground
-                            })
-                            .child(tc.name.clone()),
-                    )
-                    .child(
-                        div()
-                            .min_w_0()
-                            .truncate()
-                            .text_size(FONT_MSG_THINKING)
-                            .font_family(mono.clone())
-                            .text_color(theme.muted_foreground)
-                            .child(tc.input_preview.clone()),
-                    ),
-            );
-            if tc.is_error {
-                if let Some(out) = &tc.output {
-                    let shown: String = out.trim().chars().take(400).collect();
-                    if !shown.is_empty() {
-                        item = item.child(
+            .border_t_1()
+            .border_color(panel_border);
+        for (n, tc) in calls.iter().enumerate() {
+            let mut item = v_flex()
+                .w_full()
+                .min_w_0()
+                .px(px(13.))
+                .py(px(10.))
+                .gap(px(6.))
+                // 同一簇内多条之间用发丝线分隔,首条不画(卡片自己的顶边已在)
+                .when(n > 0, |el| el.border_t_1().border_color(panel_border));
+            // 单条时头行已给过名称
+            if calls.len() > 1 {
+                item = item.child(
+                    h_flex()
+                        .w_full()
+                        .min_w_0()
+                        .gap(px(7.))
+                        .child(
                             div()
-                                .w_full()
+                                .flex_shrink_0()
+                                .text_size(FONT_MSG_THINKING)
+                                .font_medium()
+                                .text_color(if tc.is_error {
+                                    theme.danger
+                                } else {
+                                    theme.foreground
+                                })
+                                .child(tc.name.clone()),
+                        )
+                        .child(
+                            div()
                                 .min_w_0()
-                                .px(px(8.))
-                                .py(px(5.))
-                                .rounded(RADIUS_KBD)
-                                .bg(theme.muted)
-                                .text_size(FONT_LABEL)
+                                .overflow_hidden()
+                                .whitespace_nowrap()
+                                .text_size(FONT_MSG_MONO)
                                 .font_family(mono.clone())
                                 .text_color(theme.muted_foreground)
-                                .child(shown),
-                        );
-                    }
-                }
+                                .child(clip_display(&tc.input_preview, arg_cells)),
+                        ),
+                );
+            }
+            // 优先给完整 input
+            let input = tc
+                .input
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| clip_chars(s, TOOL_OUTPUT_LIMIT));
+            if let Some(input) = input {
+                item = item.child(tool_section("Input", input, false, mono.clone(), cx));
+            }
+            if let Some(out) = tc
+                .output
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                item = item.child(tool_section(
+                    "Output",
+                    clip_chars(out, TOOL_OUTPUT_LIMIT),
+                    tc.is_error,
+                    mono.clone(),
+                    cx,
+                ));
             }
             items = items.child(item);
         }
         cluster = cluster.child(items);
     }
     cluster
+}
+
+/// 按码点截断,截断时补省略号
+fn clip_chars(s: &str, limit: usize) -> String {
+    let mut out: String = s.chars().take(limit).collect();
+    if s.chars().nth(limit).is_some() {
+        out.push('…');
+    }
+    out
+}
+
+/// 工具卡展开体里的一段(Input / Output)。失败的输出走 danger 色。
+fn tool_section(
+    label: &'static str,
+    body: String,
+    is_error: bool,
+    mono: SharedString,
+    cx: &App,
+) -> Div {
+    let theme = cx.theme();
+    v_flex()
+        .w_full()
+        .min_w_0()
+        .gap(px(4.))
+        .child(
+            div()
+                .text_size(FONT_LABEL)
+                .text_color(theme.muted_foreground)
+                .child(label),
+        )
+        .child(
+            div()
+                .w_full()
+                .min_w_0()
+                .px(px(10.))
+                .py(px(7.))
+                .rounded(RADIUS_KBD)
+                .bg(crate::theme::inline_code_bg(theme.mode.is_dark()))
+                .text_size(FONT_MSG_MONO)
+                .line_height(relative(1.65))
+                .font_family(mono)
+                .text_color(if is_error {
+                    theme.danger
+                } else {
+                    theme.muted_foreground
+                })
+                .child(body),
+        )
 }
 
 /// 小胶囊 badge(项目名/model/source 共用):4px 圆角,内部截断。
@@ -4562,6 +5131,15 @@ fn custom_owner<'a>(
         .iter()
         .find(|(a, p)| *a == agent && path_owns(p.as_ref(), root))
         .map(|(_, p)| p)
+}
+
+/// 元信息带里的分隔点。DESIGN.md 规定分隔符是前后带空格的 ` · `;这里
+/// 走 flex gap 排版,所以只画点本身,前后空隙由 gap 给
+fn meta_sep(color: Hsla) -> Div {
+    div()
+        .flex_shrink_0()
+        .text_color(color.opacity(0.55))
+        .child("·")
 }
 
 fn badge(name: impl Into<SharedString>, bg: Hsla, fg: Hsla) -> impl IntoElement {


### PR DESCRIPTION
## 背景

我原本想自己写个工具，能够将自己过往的一些会话记录保留下来。偶然在 GitHub 上看到 Wake 之后觉得做的非常棒，基本就是我想要的样子。

这几天也用量一下，遇到一些问题，主要集中在前端页面的 UI 设计上。所以想在对 UI 做一次优化升级。这个 PR 就是对 UI 的一次性整体改动，只动 `crates/wake`，不涉及数据层。数据层另有一个 Codex 分支会话的修复，单独开了 PR，两者互不依赖。

先说明一件事：**这个 PR 会覆盖 v0.2.11 里的一批 UI 微调**（详情元信息间距、列表头对齐、侧栏标题光学对齐、88px 身份区、正文不套圆角卡等）。不是没看到那些改动，而是我认为这批问题的根因需要成套解决——字阶要统一、详情头的层数要减、还要绕开 gpui 的两个限制——逐处调间距解决不了。冒犯之处请见谅，如果哪部分你更认可原来的做法，我也可以改回去。

在做的过程中发现你发布了最新的 `0.3.0` 版本，更新了 Insights 相关的功能，这部分已完整合入。

下面所有截图都是在**虚构的示例数据**上截的（会话内容、项目名、路径均为杜撰），不是我的真实记录。改动前后跑的是同一份数据、同一个窗口尺寸。

**改动前**（当前 `main`）

![改动前 · 浅色](https://raw.githubusercontent.com/Tespera/Wake/assets/pr-ui-redesign/shots/before-overview-light.png)

**改动后**（本 PR）

![改动后 · 浅色](https://raw.githubusercontent.com/Tespera/Wake/assets/pr-ui-redesign/shots/after-overview-light.png)

以下是具体修改的地方，还请审查。

---

## 一、会话列表

| 位置 | 改前 | 改后 | 为什么 |
|---|---|---|---|
| 标题 | 单行，超长时**硬裁在半个字上、没有省略号** | 按显示宽度截断 + `…` | gpui 的 `truncate()` 在虚拟列表里不生效，见文末「框架限制」 |
| 行结构 | 标题 + 元信息两行，时间在第二行 | 标题独占一行；元信息行 = agent 图标 · 项目 · 消息数 ⋯ 时间 | 中文标题信息密度高，与元信息挤一行会被压得很短 |
| 消息数 | 不在列表显示 | 每行显示 | 筛选到某个 agent 或项目后，图标和 badge 每行都一样，整列没有区分度；消息数是唯一能一眼区分的量 |
| 分组 | 平铺 | 按 Today / Yesterday / Earlier this week / 月份分组；组头为橙色竖条 + 大写标签 + 尾随发丝线 | 180 条平铺只有右侧相对时间，形不成时间锚点。组头原先只靠留白分隔，密集列表里与会话行的视觉重量太接近 |
| 置顶会话 | 混在时间分组里 | 单独成 `Pinned` 组 | **这是个 bug**：DB 层 `ORDER BY COALESCE(u.pinned,0) DESC` 把置顶排到最前，它们的时间戳与后面的行不连续，混进时间分组会切出重复组头（出现两个 Today） |
| 总数 | 无 | 标题旁角标 | `total_sessions` 字段原本只写不读；DESIGN.md 的「会话流」一节本来就要求这个角标 |
| 截断提示 | 超出 `limit` 时静默截断 | 底部说明「Showing the N most recent of M」 | 侧栏计数是全库总数、列表却只有前 N 条，两个数字互相矛盾且无解释。上限同时从 500 提到 2000 |
| 空态 | 恒为「No matching sessions / Try different filters」 | 分四种：索引中（带进度）／索引失败／有筛选无结果／全库为空 | **首次全量扫描期间列表本来就是空的**，此时既没有筛选也没有查询，原文案是错的 |

## 二、详情头部

原本六层（身份 / 标题 / 项目路径 / model+统计 / 精确时间 / JSONL 文件路径），在 900px 高的窗口里吃掉约 28% 的垂直空间。现在**两层**：

1. 会话标题（单行，按可用宽度截断，全文进 tooltip）+ 操作区
2. 单条元信息带：品牌图标 · Agent · 项目 · 分支 · model · 消息数 · token · 相对时间

三处信息收进 tooltip 或菜单，不再占位：

- **项目完整路径** → 项目名的 tooltip（点击仍然 Reveal）
- **精确到秒的 Created / Updated** → 相对时间的 tooltip
- **会话 JSONL 文件路径** → 整行删除。中段是 UUID，对人不可读；Reveal 入口在 `…` 菜单里已经有了

另外两处：

- **分支名为 `HEAD` / `detached` / 空时整块不渲染**。detached HEAD 状态下透传的 "HEAD" 对用户零信息量
- **model 从 outline badge 改为同级 muted 文字**。原先那个 badge 用的是 `MODEL_BADGE_BG`（Claude 橙 `#D97757`），但它被套在**所有** agent 上——Codex 会话的 model 也是橙色的，与 DESIGN.md 里「Agent 身份只由品牌图标表达」冲突，且在标题旁视觉重量过高

## 三、三栏对齐

会话流与详情头改用同一个顶部偏移，两栏标题因此等高，会话流的首个日期组头与详情的元信息带齐平。

这里覆盖了 v0.2.11 的 `LIBRARY_IDENTITY_HEIGHT`（88px 固定高度身份区 + 垂直居中）——**在那个模型下这两件事无法兼得**：会话流的头部只有标题一行，详情头有标题与元信息两行，居中之下两块内容必然错开；对齐了标题，组头就对不上元信息。改成顶部固定偏移后两者同时成立。该常量现在只剩侧栏在用。

阅读卡的圆角与外边距也恢复了（v0.2.11 改成了「正文横向铺满、不再套圆角大卡」）。

## 四、对话正文

对标 Claude Desktop 的阅读形制。**用户消息保留右对齐气泡**，助手消息全宽平铺，角色靠形态区分、不加文字标签。

换一个短会话看气泡、标题层级与代码块（同样是示例数据）：

**改动前**

![改动前 · 正文](https://raw.githubusercontent.com/Tespera/Wake/assets/pr-ui-redesign/shots/before-transcript.png)

**改动后**

![改动后 · 正文](https://raw.githubusercontent.com/Tespera/Wake/assets/pr-ui-redesign/shots/after-transcript.png)

**字号 / 行宽 / 行高是一组，必须一起改**：正文 13px → **14.5px**，列宽 720px → **612px**（约 42 个中文字一行），行高约 1.5 → **1.92**。汉字没有 x-height 起伏、字面率高，Latin-only 场景常用的 1.5–1.6 放到中文上明显发挤；只提字号不收列宽，每行字数会涨到 46 个，反而更难读。

| 项 | 改前 | 改后 |
|---|---|---|
| markdown 层级 | 只有段落、列表、代码块 | 补齐 h1–h4 分级、表格、引用块、分隔线 |
| 标题间距 | 与普通段距相同，层级读不出来 | 按层级分级（h1 30 / h2 25 / h3 20 / h4+ 16px），见文末「框架限制」 |
| 代码块 | 无标识 | 右上角挂语言名 + 复制按钮（`code_block_actions`） |
| thinking | **永久截断为一行、无展开路径** | 可折叠面板，收起给摘要、展开是全文 |
| 工具调用 | 头行只有工具名（`Bash`、`Read`），看不出操作对象 | 折叠卡：名称 + **参数摘要** + 结果徽标；展开看输入与输出 |
| 工具输出 | **只在 `is_error` 时渲染** | 成功调用的输出同样显示 |
| 轮次间距 | 6px | 15px，多轮对话有边界 |
| 行内代码 | 底色偏重 | 降档（经 `theme.accent`，组件写死取它） |

工具输出那条想多说一句：原实现只保留失败项，等于把绝大多数工具结果丢掉了，而这是个「回看历史」的工具——想知道那次 grep 到底搜出了什么，只能去 Finder 翻原始 JSONL。

## 五、缺陷修复

- **会话解析失败没有错误态**：`open_detail` 的后台任务失败时只把 `loading` 置 false，`transcript` 仍是空 `Vec`，右栏渲染出一张完全空白的阅读卡，不解释也没有下一步。现在显示原因 + Reveal 按钮
- **搜索跳转在超出当前页的会话上静默失效**（`limit` 提高后大幅缓解，根治需要分页）

## 六、其它

- **窗口尺寸按屏幕自适应**：固定 1180×760 在较大的屏上偏小，阅读区只剩 620pt。改为取屏幕的 78% × 82%，钳进 `[940×620, 1400×900]`。给上限是因为正文列宽固定，窗口再宽多出来的只是空白
- **关掉 macOS 标题栏分隔线**：gpui 设了 `titlebarAppearsTransparent = YES` 但没动 `titlebarSeparatorStyle`，默认 `Automatic` 会在深色下画出一条亮线。gpui 未暴露该开关，走 objc 运行时关（`crates/wake/src/macos.rs`，`objc` 本来就在依赖树里）
- **Insights**：形态与配色未动，只做了四处规范修正——概览数字从 22px 提到 28px（原本与中栏标题同级，不像页面主角）、组间距与榜单行高归 4px 网格、把重复的 `px(2.)` 数据格圆角提成 `RADIUS_CELL` 常量

---

## 深色模式

同一屏在深色下的样子：

**改动前**

![改动前 · 深色](https://raw.githubusercontent.com/Tespera/Wake/assets/pr-ui-redesign/shots/before-overview-dark.png)

**改动后**

![改动后 · 深色](https://raw.githubusercontent.com/Tespera/Wake/assets/pr-ui-redesign/shots/after-overview-dark.png)

---

## 踩到的三个框架限制

这几条是排查过程中确认的客观行为，写下来免得后续重踩。

### 1. `truncate()` / `text_ellipsis()` 在虚拟列表里不画省略号

gpui 在 `elements/text.rs:357` 只有拿到 `known_dimensions.width` 或 `AvailableSpace::Definite` 时才截断并补 `…`；虚拟列表（`v_virtual_list`）行内与 flex 子项都拿不到确定宽度，文字于是按 max-content 铺开，再被外层 `overflow_hidden` 硬裁——中文正好切在半个字上。

试过四种结构都不生效：标题带 `flex_1()`、去掉 `flex_1` 配弹性占位、把标题提成行容器的直接子级、去掉 `ListItem` 的 `mx`。**给文字元素显式 `.w()` 也不管用。**

所以定宽处一律走 `format::clip_display(s, cells)` 按显示宽度自截断（CJK / 全角记 2 格）。两点值得注意：

- 宽度会变的地方，**格数必须从当前像素宽反算**，写死会让「窗口拉宽后截断长度不补齐」
- **省略号自己占两格**。`…` 是全角，只留一格时截出来的串会超出容器、`…` 正好落在边界外被裁，看起来就是「截断了但没有省略号」。有单测钉住这条

另外 `List` 只测量一行的高度然后套给所有行（`list.rs:406`），所以列表行绝不能换行，`whitespace_nowrap()` 必须留着。

### 2. markdown 标题的上方间距没有钩子

组件的标题渲染只有 `pb(rems(0.3))`、**没有 `pt`**（`node.rs` 的 `Node::Heading` 分支），标题上方的间距完全来自前一个块的 `paragraph_gap`——和两个普通段落之间一模一样，所以标题读不出层级。

**调大 `paragraph_gap` 不解决问题**：它把段间距和标题上间距一起放大，相对关系不变。`TextViewStyle` 也没有对应钩子。

本 PR 的做法是把 ATX 标题从 markdown 里切出来单独渲染（`markdown_message` + `split_markdown_blocks`），上间距由外层 div 按层级给。切块只认 `# ` ~ `###### `，并跟踪围栏代码块状态，代码里的 `# ` 注释不会被误判。

**代价**：一条消息会拆成多个 `TextView` 实例，跨块的文字选择会断在块边界。如果你认为这个代价不值，这部分可以单独回退，其余改动不受影响。

### 3. 代码块跟随深浅切换有两个坑

一是 `TextViewStyle.highlight_theme` 默认恒为 `default_light()`，深色下代码块是浅色配色；二是 `TextViewStyle` 的 `PartialEq` **只**比较 `paragraph_gap` / `heading_base_font_size` / `highlight_theme`——`is_dark` 与 `code_block` 都不参与，不换 `highlight_theme` 的话新旧 style 会被判定相等，组件根本不重建。

即便配色对了还有第二拍：`TextView` 只在首次 `request_layout` 时同步解析，之后 style 变化走异步通道（`UpdateFuture` 带 200ms debounce + 后台重新解析），而语法高亮的颜色是在**解析阶段**固化进 `CodeBlock.styles` 的。所以本 PR 把深浅模式写进了 `TextView` 的 id：主题一换 id 就变，被视作新元素、走首次的同步解析路径。

---

## 未做的事

- **中西文混排的字距补偿**做不了：gpui 的 `Styled` 没有 `letter_spacing`
- **表格列宽会溢出正文列**：`render_table` 把每列的字符数直接当相对宽度用（`.w(Length::Definite(relative(len as f32)))`，`relative(30.0)` = 容器宽的 3000%），单元格上的 `.truncate()` 也因为宽度"确定"而不触发。属组件层，本 PR 未动
- **行内代码无法加圆角**：底色走 gpui 的 text run `background_color`，绘制是 `window.paint_quad(fill(..))`，`fill()` 无 `corner_radii`，高度还锁死为 `line_height`

---

## 验证

- `cargo build -p wake`、`cargo fmt --all -- --check`、`cargo clippy` 均无新增警告
- `cargo test -p wake-core` / `-p wake` 全绿
- 在 180 会话的真实数据上逐屏核对过浅色与深色两种外观

DESIGN.md 已同步更新，包括新增的「文字截断」一节（记录上面第 1 条限制与各处的格数依据）。

