### PR TITLE
fix(terminal): name agent and CLI in resume not-found errors

### DIFF
--- a/crates/wake-core/src/services/terminal/macos.rs
+++ b/crates/wake-core/src/services/terminal/macos.rs
@@ -322,7 +322,10 @@ fn launch_kooky_cli(meta: &SessionMeta) -> ResumeOutcome {
     let Some(exe) = resolve_cli(bin) else {
         return fail(
             String::new(),
-            format!("Command {bin} not found — is it installed?"),
+            format!(
+                "CLI `{bin}` (for {}) not found in shell PATH — is it installed?",
+                meta.agent.display_name()
+            ),
         );
     };
     let cmd = std::iter::once(exe.as_str())

--- a/crates/wake-core/src/services/terminal/mod.rs
+++ b/crates/wake-core/src/services/terminal/mod.rs
@@ -169,8 +169,9 @@ pub fn resume_session_in(meta: &SessionMeta, term: TerminalApp) -> ResumeOutcome
             ok: false,
             command: String::new(),
             error: Some(format!(
-                "Command {} not found — is it installed?",
-                bin.unwrap_or("?")
+                "CLI `{}` (for {}) not found in shell PATH — is it installed?",
+                bin.unwrap_or("?"),
+                meta.agent.display_name()
             )),
         };
     };


### PR DESCRIPTION
Fixes #17

## Problem

The resume failure message `Command omp not found — is it installed?` names neither the terminal app, nor the agent, nor which CLI. Users with the terminal installed read it as "the terminal is missing" and chase the wrong layer (install terminals, restart) while the actual gap is the agent CLI in the login-shell PATH.

## Change

Both failure sites (`resume_session_in` and the Kooky kooky-cli path) now report:

> CLI `omp` (for Oh My Pi) not found in shell PATH — is it installed?

i.e. the missing CLI, the agent it belongs to, and the searched scope.

## Verification

- `cargo test -p wake-core` passes (compile + lib tests) on this branch alone; combined with the other two fix branches 22/22.
- No tests asserted on the previous copy; both call sites updated.

Companion PRs: #18 (probe ANSI robustness, fixes #15), #19 (miss caching, fixes #16). Branches are independent — no overlapping hunks, mergeable in any order.