### PR TITLE
Open in Claude Desktop / Codex Desktop with per-agent memory (v0.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.3.5] — 2026-09-02
+
 - New: Open in now offers Claude Desktop for Claude Code sessions and Codex Desktop for Codex sessions, jumping straight to that session in the desktop app
 - New: Open in remembers your last choice per agent and keeps it across restarts
 - Fix: opening a session in Claude Desktop no longer creates a duplicate copy when the conversation already lives there

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- New: Open in now offers Claude Desktop for Claude Code sessions and Codex Desktop for Codex sessions, jumping straight to that session in the desktop app
+- New: Open in remembers your last choice per agent and keeps it across restarts
+- Fix: opening a session in Claude Desktop no longer creates a duplicate copy when the conversation already lives there
+- Update: Codex Desktop now shows the Codex brand icon in Open in instead of the ChatGPT app icon
+
 ## [0.3.4] — 2026-09-01
 
 - New: inline images from every readable agent transcript format now appear with compact thumbnails, full-window zoom, copy, and collision-safe save-to-Downloads actions; unsupported image formats can still be saved in their original bytes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7740,7 +7740,7 @@ dependencies = [
 
 [[package]]
 name = "wake"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7763,7 +7763,7 @@ dependencies = [
 
 [[package]]
 name = "wake-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/wake-core", "crates/wake"]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT"
 

--- a/crates/wake-core/src/db.rs
+++ b/crates/wake-core/src/db.rs
@@ -87,6 +87,14 @@ CREATE TABLE IF NOT EXISTS removed_default_roots (
   PRIMARY KEY (agent, path)
 );
 
+-- 应用级 UI 偏好。与 schema_meta 同形但语义不同:schema_meta 是索引
+-- 自身的迁移状态,迁移代码可随意增删;prefs 是用户数据(user_data 同类,
+-- 只是不挂在会话上),勿合并两表
+CREATE TABLE IF NOT EXISTS prefs (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS disabled_locations (
   agent       TEXT NOT NULL,
   path        TEXT NOT NULL,
@@ -446,6 +454,29 @@ impl Store {
                 pinned.map(|v| v as i64),
                 now_ms()
             ],
+        )?;
+        Ok(())
+    }
+
+    /// 应用级 KV 偏好(Open In 目标记忆等 UI 状态)。value 语义由调用方定
+    /// (多为 json),不存在回 None
+    pub fn pref_get(&self, key: &str) -> Option<String> {
+        let conn = self.write.lock().unwrap();
+        conn.query_row(
+            "SELECT value FROM prefs WHERE key = ?1",
+            params![key],
+            |r| r.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten()
+    }
+
+    pub fn pref_set(&self, key: &str, value: &str) -> Result<()> {
+        let conn = self.write.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO prefs(key, value) VALUES (?1, ?2)",
+            params![key, value],
         )?;
         Ok(())
     }

--- a/crates/wake-core/src/services/terminal/linux.rs
+++ b/crates/wake-core/src/services/terminal/linux.rs
@@ -72,6 +72,11 @@ impl TerminalApp {
         }
     }
 
+    /// 内嵌品牌图标覆盖(macOS 的 Codex desktop 用;此平台无深链目标)
+    pub fn brand_icon(&self) -> Option<&'static str> {
+        None
+    }
+
     /// spawn 前缀:`<bin> <prefix…> <argv…>`,prefix 是各家"后面全是命令 argv"
     /// 的开关——gnome-terminal/kgx 用 `--`,wezterm 是子命令 `start --`,
     /// xfce4-terminal 用 `-x`(-e 是单串旧式),kitty 裸接,其余 `-e`

--- a/crates/wake-core/src/services/terminal/macos.rs
+++ b/crates/wake-core/src/services/terminal/macos.rs
@@ -1,6 +1,6 @@
 //! macOS 平台原语:AppleScript/`open` 驱动的终端与 Finder、Finder 废纸篓、
-//! Kooky 深链。接口与 linux.rs 同形,策略(dir/file 分发、路径过滤、
-//! 线程化)在 mod.rs,这里只做动作本身。
+//! 深链目标(Kooky、Claude Desktop、Codex Desktop)。接口与 linux.rs 同形,
+//! 策略(dir/file 分发、路径过滤、线程化)在 mod.rs,这里只做动作本身。
 
 use super::{
     cli_not_found_error, percent_encode, pipe_to, posix_quote, resolve_cli, resume_args,
@@ -24,17 +24,26 @@ fn osascript(lines: &[String]) -> std::io::Result<std::process::Output> {
     cmd.output()
 }
 
-/// Open In 下拉的目标终端。只列本机实际安装且可程序化注入命令的
-/// (Tabby 等无稳定命令接口的不做)。
+/// Open In 下拉的目标。shell 类只列本机实际安装且可程序化注入命令的
+/// (Tabby 等无稳定命令接口的不做);深链类(Kooky/两家 desktop)不跑
+/// shell,由 deep_link_resume 整锅接管。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TerminalApp {
     Terminal,
     ITerm,
     Warp,
     Ghostty,
-    /// 用户自己的 agent 宿主 app。暂无外部接口(无 URL scheme、不收 open
-    /// 参数),只能激活应用,不能带会话跳转。
+    /// 用户自己的 agent 宿主 app:roster 内走 kooky://resume 深链,
+    /// 名单外经 kooky-cli 哑管道传命令文本(见 launch_kooky)。
     Kooky,
+    /// Claude Desktop 内嵌的 Claude Code:claude://resume?session=<uuid>
+    /// 把磁盘上的 CLI transcript 导入 desktop 会话并聚焦(实测 2026-09-01,
+    /// 处理端是 app.asar 的 claudeURLHandler,id 校验为裸 UUID)。
+    ClaudeDesktop,
+    /// Codex 桌面版(app 名叫 ChatGPT.app,bundle id com.openai.codex):
+    /// codex://threads/<uuid> 打开本地会话(路由 kind "localConversation",
+    /// desktop 的 threads 表与 CLI 共库、行内 rollout_path 即 CLI 文件)。
+    CodexDesktop,
 }
 
 impl TerminalApp {
@@ -45,6 +54,8 @@ impl TerminalApp {
             TerminalApp::Warp => "Warp",
             TerminalApp::Ghostty => "Ghostty",
             TerminalApp::Kooky => "Kooky",
+            TerminalApp::ClaudeDesktop => "Claude Desktop",
+            TerminalApp::CodexDesktop => "Codex Desktop",
         }
     }
 
@@ -56,10 +67,23 @@ impl TerminalApp {
             TerminalApp::Warp => "warp",
             TerminalApp::Ghostty => "ghostty",
             TerminalApp::Kooky => "kooky",
+            TerminalApp::ClaudeDesktop => "claude-desktop",
+            TerminalApp::CodexDesktop => "codex-desktop",
         }
     }
 
-    /// 已安装的 .app 绝对路径(首个命中)
+    /// 内嵌品牌图标覆盖:Codex desktop 的 .app 图标是 ChatGPT 的(留白也
+    /// 比别家多,渲染出来偏小),Open In 里应与 Codex agent 图标一致,
+    /// 直接用内嵌 brands 资源,不走 ensure_app_icons 的提取缓存
+    pub fn brand_icon(&self) -> Option<&'static str> {
+        match self {
+            TerminalApp::CodexDesktop => Some("brands/codex.png"),
+            _ => None,
+        }
+    }
+
+    /// 已安装的 .app 绝对路径(首个命中;/Applications 之外再试
+    /// ~/Applications 下同名 bundle)
     pub fn resolved_app_path(&self) -> Option<std::path::PathBuf> {
         let candidates: &[&str] = match self {
             TerminalApp::Terminal => &["/System/Applications/Utilities/Terminal.app"],
@@ -67,18 +91,37 @@ impl TerminalApp {
             TerminalApp::Warp => &["/Applications/Warp.app"],
             TerminalApp::Ghostty => &["/Applications/Ghostty.app"],
             TerminalApp::Kooky => &["/Applications/Kooky.app"],
+            TerminalApp::ClaudeDesktop => &["/Applications/Claude.app"],
+            // Codex desktop 的 app 名与旧版 ChatGPT 同名,靠 bundle id 区分
+            TerminalApp::CodexDesktop => &["/Applications/ChatGPT.app"],
         };
-        for p in candidates {
-            let p = std::path::PathBuf::from(p);
-            if p.is_dir() {
-                return Some(p);
+        let home = dirs::home_dir().unwrap_or_default().join("Applications");
+        for c in candidates {
+            let sys = std::path::PathBuf::from(c);
+            let alt = std::path::Path::new(c).file_name().map(|n| home.join(n));
+            for p in std::iter::once(sys).chain(alt) {
+                if p.is_dir() && self.bundle_marker_ok(&p) {
+                    return Some(p);
+                }
             }
         }
-        let home_app = dirs::home_dir()
-            .unwrap_or_default()
-            .join("Applications")
-            .join(format!("{}.app", self.display_name()));
-        home_app.is_dir().then_some(home_app)
+        None
+    }
+
+    /// display 名不足以认 app 的变体按 bundle id 验明正身(Info.plist 里
+    /// bundle id 是明文 ASCII,XML/二进制两种 plist 都直接搜得到):
+    /// ChatGPT.app 只有 Codex 版(com.openai.codex)才注册 codex:// scheme,
+    /// 旧版 ChatGPT 同名不同物;Claude.app 同理防重名壳。一次性探测
+    /// (installed_terminals 进程内缓存),读几 KB plist 无感。
+    fn bundle_marker_ok(&self, app: &Path) -> bool {
+        let marker: &[u8] = match self {
+            TerminalApp::ClaudeDesktop => b"com.anthropic.claudefordesktop",
+            TerminalApp::CodexDesktop => b"com.openai.codex",
+            _ => return true,
+        };
+        std::fs::read(app.join("Contents/Info.plist"))
+            .map(|data| data.windows(marker.len()).any(|w| w == marker))
+            .unwrap_or(false)
     }
 
     fn is_installed(&self) -> bool {
@@ -86,21 +129,28 @@ impl TerminalApp {
     }
 }
 
-/// 深链类目标整锅接管 resume(不经 agent CLI)。Kooky 是本平台唯一一例;
-/// 新增非 shell 目标在此声明,mod.rs 的 resume_session_in 无需加旁路。
+/// 深链类目标整锅接管 resume(不经 agent CLI)。新增非 shell 目标在此
+/// 声明,mod.rs 的 resume_session_in 无需加旁路。
 pub(super) fn deep_link_resume(meta: &SessionMeta, term: TerminalApp) -> Option<ResumeOutcome> {
-    (term == TerminalApp::Kooky).then(|| launch_kooky(meta))
+    match term {
+        TerminalApp::Kooky => Some(launch_kooky(meta)),
+        TerminalApp::ClaudeDesktop => Some(launch_claude_desktop(meta)),
+        TerminalApp::CodexDesktop => Some(launch_desktop_id(&meta.id, "codex://threads/", term)),
+        _ => None,
+    }
 }
 
 /// Shell 类目标的命令注入分发(深链目标已被 deep_link_resume 拦下,
-/// Kooky 臂只是护栏)
+/// 深链臂只是护栏)
 pub(super) fn launch_shell(term: TerminalApp, command: &str) -> anyhow::Result<()> {
     match term {
         TerminalApp::Terminal => launch_terminal_app(command),
         TerminalApp::ITerm => launch_iterm(command),
         TerminalApp::Warp => launch_warp(command),
         TerminalApp::Ghostty => launch_ghostty(command),
-        TerminalApp::Kooky => anyhow::bail!("Kooky is a deep-link target"),
+        TerminalApp::Kooky | TerminalApp::ClaudeDesktop | TerminalApp::CodexDesktop => {
+            anyhow::bail!("{} is a deep-link target", term.display_name())
+        }
     }
 }
 
@@ -196,16 +246,24 @@ fn kooky_speaks(agent: AgentId) -> bool {
     KOOKY_ROSTER.contains(&agent) || kooky_cli_path().is_some()
 }
 
-/// 某会话可用的恢复目标(Kooky 按 agent 过滤,见 kooky_speaks)
+/// 某会话可用的恢复目标(Kooky 按 agent 过滤见 kooky_speaks;两家 desktop
+/// 只认自家 agent 的会话——深链 id 命名空间互不相通)
 pub fn terminals_for(agent: AgentId) -> Vec<TerminalApp> {
     installed_terminals()
         .iter()
         .copied()
-        .filter(|t| *t != TerminalApp::Kooky || kooky_speaks(agent))
+        .filter(|t| match t {
+            TerminalApp::Kooky => kooky_speaks(agent),
+            TerminalApp::ClaudeDesktop => agent == AgentId::ClaudeCode,
+            TerminalApp::CodexDesktop => agent == AgentId::Codex,
+            _ => true,
+        })
         .collect()
 }
 
-/// 已安装终端(启动后不变,进程内缓存)
+/// 已安装终端(启动后不变,进程内缓存)。首位是 terminals_for 的回退值
+/// (偏好被会话过滤时左段按钮显示它),恒为 Terminal——desktop 目标排在
+/// Kooky 侧属"宿主 app"一档,不抢默认。
 pub fn installed_terminals() -> &'static [TerminalApp] {
     use std::sync::OnceLock;
     static CACHE: OnceLock<Vec<TerminalApp>> = OnceLock::new();
@@ -213,6 +271,8 @@ pub fn installed_terminals() -> &'static [TerminalApp] {
         [
             TerminalApp::Terminal,
             TerminalApp::Kooky,
+            TerminalApp::ClaudeDesktop,
+            TerminalApp::CodexDesktop,
             TerminalApp::ITerm,
             TerminalApp::Warp,
             TerminalApp::Ghostty,
@@ -426,6 +486,128 @@ fn launch_kooky(meta: &SessionMeta) -> ResumeOutcome {
     }
 }
 
+/// Claude/Codex 桌面版深链。两端处理器只认裸 UUID 形态的会话 id(实测
+/// 2026-09-01:Claude 的 claudeURLHandler 与 Codex 的 threads 路由同为
+/// 8-4-4-4-12 hex 校验),而 Wake 这两家 adapter 的 native id 恰是该形态
+/// ——不匹配就地报错,别发一条对端静默丢弃的 URL(`open` 对已注册 scheme
+/// 恒退 0,拒绝在 Wake 侧看不见)。app 侧的失败(transcript 不在盘上、
+/// 会话正被 CLI 占用)由 desktop 自己弹 toast,Wake 与 Kooky 深链同款
+/// 只报"已送达"。
+///
+/// Claude Desktop 的深链导入只按 `local_<传入id>` 精确查重,不认会话链
+/// 归属(desktop 内 resume picker 走 resolveForResume 才认)。已导入的
+/// desktop 会话续聊后,其 CLI 链会推进到新 id——此时 Wake 直发盘上
+/// transcript 的 id,desktop 会给同一条对话再复制一个会话。所以深链前
+/// 先只读扫一遍 desktop 的会话索引(claude-code-sessions/<acct>/<org>/
+/// local_*.json,每条含 cliSessionId/unarchivedCliSessionId/
+/// preClearCliSessionId),命中就改发那条记录自己的 stem uuid,desktop
+/// 对已存在的 local_<stem> 走复用+聚焦(实测 2026-09-01)。
+fn launch_claude_desktop(meta: &SessionMeta) -> ResumeOutcome {
+    // 非 UUID(含坏文件产生的空 id)直接走 launch_desktop_id 的报错路径,
+    // 不进索引扫描——空 needle 会让预筛的 windows(0) panic
+    let id = is_uuid(&meta.id)
+        .then(|| claude_desktop_owned_stem(&meta.id))
+        .flatten()
+        .unwrap_or_else(|| meta.id.clone());
+    launch_desktop_id(&id, "claude://resume?session=", TerminalApp::ClaudeDesktop)
+}
+
+/// 在 desktop 会话索引里找拥有 `cli_id` 的会话,返回其 stem uuid。
+/// 索引是数百个 KB 级 json,每次点击现扫(读几 ms,别缓存——desktop
+/// 侧随时在写)。解析失败/结构不符的文件跳过,扫不到回 None 走原 id。
+fn claude_desktop_owned_stem(cli_id: &str) -> Option<String> {
+    // home_dir 走 adapters 的 WAKE_HOME 改道,fixture 测试可以铺假索引
+    let root = crate::adapters::home_dir()?
+        .join("Library/Application Support/Claude/claude-code-sessions");
+    let sub = |d: std::fs::DirEntry| std::fs::read_dir(d.path()).into_iter().flatten().flatten();
+    // desktop 可能留有多个 <acct>/<org> 目录,而 claude://resume 只在当前
+    // 登录账户下找 local_<stem>;当前账户 Wake 无从得知,多份命中时取
+    // mtime 最新的记录(基本即活跃账户),别听目录枚举顺序的
+    std::fs::read_dir(root)
+        .ok()?
+        .flatten()
+        .flat_map(sub)
+        .flat_map(sub)
+        .filter_map(|f| {
+            let p = f.path();
+            let stem = owned_stem_in(&p, cli_id)?;
+            let mtime = std::fs::metadata(&p).and_then(|m| m.modified()).ok();
+            Some((mtime, stem))
+        })
+        .max_by_key(|(mtime, _)| *mtime)
+        .map(|(_, stem)| stem)
+}
+
+/// 单条索引记录的归属判定。先做字节级预筛——绝大多数文件不含这个 id,
+/// 省掉整篇 json 解析(命中的通常恰一份)。调用方保证 cli_id 非空
+/// (空 needle 会 panic)
+fn owned_stem_in(p: &Path, cli_id: &str) -> Option<String> {
+    if p.extension().and_then(|e| e.to_str()) != Some("json") {
+        return None;
+    }
+    let data = std::fs::read(p).ok()?;
+    let needle = cli_id.as_bytes();
+    if !data.windows(needle.len()).any(|w| w == needle) {
+        return None;
+    }
+    let v = serde_json::from_slice::<serde_json::Value>(&data).ok()?;
+    // 标量三字段 + 历史数组(多次 clear/resume 后旧 CLI id 归档在
+    // priorCliSessionIds 里,漏了它老会话又会被重复导入)
+    let owns = [
+        "cliSessionId",
+        "unarchivedCliSessionId",
+        "preClearCliSessionId",
+    ]
+    .iter()
+    .any(|k| v.get(k).and_then(|x| x.as_str()) == Some(cli_id))
+        || v.get("priorCliSessionIds")
+            .and_then(|x| x.as_array())
+            .is_some_and(|a| a.iter().any(|x| x.as_str() == Some(cli_id)));
+    owns.then(|| {
+        v.get("sessionId")?
+            .as_str()?
+            .strip_prefix("local_")
+            .filter(|s| is_uuid(s))
+            .map(str::to_string)
+    })
+    .flatten()
+}
+
+fn launch_desktop_id(id: &str, prefix: &str, term: TerminalApp) -> ResumeOutcome {
+    if !is_uuid(id) {
+        return ResumeOutcome {
+            ok: false,
+            command: String::new(),
+            error: Some(format!(
+                "{} can only open sessions with a UUID id (got `{id}`)",
+                term.display_name(),
+            )),
+        };
+    }
+    let url = format!("{prefix}{id}");
+    let ok = Command::new("open")
+        .arg(&url)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    ResumeOutcome {
+        ok,
+        command: url,
+        error: (!ok).then(|| format!("Couldn't open {}", term.display_name())),
+    }
+}
+
+/// 裸 UUID(8-4-4-4-12 hex,大小写不限)——与两家 desktop 深链处理器的
+/// 校验正则同构
+fn is_uuid(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() == 36
+        && b.iter().enumerate().all(|(i, c)| match i {
+            8 | 13 | 18 | 23 => *c == b'-',
+            _ => c.is_ascii_hexdigit(),
+        })
+}
+
 /// 逐文件让 Finder 删进废纸篓(osascript 首次触发自动化授权会停等用户
 /// 点选,可能长阻塞;首错即断,已删的留在废纸篓可恢复)
 pub(super) fn trash_existing(paths: &[&str]) -> anyhow::Result<()> {
@@ -465,4 +647,69 @@ pub(super) fn reveal_path(path: &str) {
     let mut cmd = Command::new("open");
     cmd.args(["-R", path]);
     let _ = spawn_and_reap(cmd);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_gate_matches_desktop_handlers() {
+        assert!(is_uuid("01937a56-3a2c-43af-af68-a8d4e00d60ed"));
+        assert!(is_uuid("01A05A8B-2BB4-7DB3-B72C-3E9AAB7DF290")); // 大小写不限
+        assert!(!is_uuid("last"));
+        assert!(!is_uuid("local_01937a56-3a2c-43af-af68-a8d4e00d60ed"));
+        assert!(!is_uuid("01937a56-3a2c-43af-af68-a8d4e00d60e")); // 短一位
+        assert!(!is_uuid("01937a56x3a2c-43af-af68-a8d4e00d60ed")); // 错位分隔符
+        assert!(!is_uuid(""));
+    }
+
+    /// 非 UUID id 必须就地报错而不是发 URL——`open` 对已注册 scheme 恒退 0,
+    /// 发出去的坏 id 在 Wake 侧看不见失败
+    #[test]
+    fn desktop_deep_link_rejects_non_uuid_id_without_launching() {
+        let meta = crate::models::SessionMeta {
+            key: "claude-code:not-a-uuid".into(),
+            id: "not-a-uuid".into(),
+            agent: crate::models::AgentId::ClaudeCode,
+            title: String::new(),
+            project_path: String::new(),
+            project_name: String::new(),
+            file_path: String::new(),
+            created_at: 0,
+            updated_at: 0,
+            message_count: 0,
+            size_bytes: 0,
+            git_branch: None,
+            model: None,
+            tokens_used: None,
+            archived: false,
+            source: None,
+            favorite: false,
+            pinned: false,
+        };
+        for term in [TerminalApp::ClaudeDesktop, TerminalApp::CodexDesktop] {
+            let outcome = deep_link_resume(&meta, term).expect("desktop targets are deep-link");
+            assert!(!outcome.ok);
+            assert!(
+                outcome.command.is_empty(),
+                "must not build a URL for a bad id"
+            );
+            assert!(outcome
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains(term.display_name())));
+        }
+    }
+
+    #[test]
+    fn shell_launch_refuses_deep_link_targets() {
+        for term in [
+            TerminalApp::Kooky,
+            TerminalApp::ClaudeDesktop,
+            TerminalApp::CodexDesktop,
+        ] {
+            assert!(launch_shell(term, "echo hi").is_err());
+        }
+    }
 }

--- a/crates/wake-core/src/services/terminal/mod.rs
+++ b/crates/wake-core/src/services/terminal/mod.rs
@@ -170,8 +170,9 @@ fn resume_args(agent: AgentId, id: &str) -> Option<(Vec<String>, bool)> {
 }
 
 pub fn resume_session_in(meta: &SessionMeta, term: TerminalApp) -> ResumeOutcome {
-    // 深链类目标(macOS Kooky)由平台整锅接管,不走 shell 命令构建;
-    // 新增非 shell 目标在平台的 deep_link_resume 里声明,这里无需加旁路
+    // 深链类目标(macOS 的 Kooky / Claude Desktop / Codex Desktop)由平台
+    // 整锅接管,不走 shell 命令构建;新增非 shell 目标在平台的
+    // deep_link_resume 里声明,这里无需加旁路
     if let Some(outcome) = platform::deep_link_resume(meta, term) {
         return outcome;
     }

--- a/crates/wake-core/src/services/terminal/windows.rs
+++ b/crates/wake-core/src/services/terminal/windows.rs
@@ -70,6 +70,11 @@ impl TerminalApp {
         }
     }
 
+    /// 内嵌品牌图标覆盖(macOS 的 Codex desktop 用;此平台无深链目标)
+    pub fn brand_icon(&self) -> Option<&'static str> {
+        None
+    }
+
     /// 此宿主自身不是 shell,得再装一个 PowerShell 会话才跑得起命令
     /// (terminals_for 据此在没有 PowerShell 的机器上藏掉它们)
     fn needs_powershell(&self) -> bool {

--- a/crates/wake/src/workbench.rs
+++ b/crates/wake/src/workbench.rs
@@ -1866,7 +1866,14 @@ pub struct Workbench {
     /// 终端 id → 提取好的应用图标 png(后台 JXA 提取,详情页 Open In 用)
     terminal_icons: HashMap<String, PathBuf>,
     /// Open In 上次选择(split 按钮左段直开目标),None = 已装列表首个
-    preferred_terminal: Option<terminal::TerminalApp>,
+    /// Open In 上次选择,按 agent 分记:agent 专属目标(两家 desktop、Kooky)
+    /// 只对自家会话有意义,单一全局值会被后选的专属目标冲掉,回头另一家
+    /// 会话就回退 Terminal(2026-09-01 用户反馈)。跨 agent 的次级回退走
+    /// `last_terminal`
+    preferred_terminal: HashMap<AgentId, terminal::TerminalApp>,
+    /// 最近一次显式选择(不分 agent),per-agent 无记录时若仍在该会话的
+    /// 可用列表内则用它——让"一直用 Ghostty"的人不用每家 agent 都选一遍
+    last_terminal: Option<terminal::TerminalApp>,
     _subs: Vec<Subscription>,
 }
 
@@ -2156,9 +2163,11 @@ impl Workbench {
             scan_events,
             watcher,
             terminal_icons: HashMap::new(),
-            preferred_terminal: None,
+            preferred_terminal: HashMap::new(),
+            last_terminal: None,
             _subs: subs,
         };
+        this.load_open_in_prefs();
         this.refresh(cx);
         this._calendar_task = Some(cx.spawn(async move |this, cx| loop {
             cx.background_executor()
@@ -3890,21 +3899,78 @@ impl Workbench {
         .detach();
     }
 
-    /// remember=false:本次目标是"偏好在这个会话上不可用"时的回退值(见 render
-    /// 里的 terminals_for),点它不该把回退值写成新偏好——否则一个 dsh 会话就能
-    /// 把用户的 Kooky 偏好冲成 Terminal,再回 Claude 会话也回不去了
+    // ---------- Open In 目标记忆 ----------
+
+    /// Open In 目标解析:本 agent 的记忆 → 最近全局选择(仍可用时)→
+    /// 列表首项
+    fn open_in_target(
+        &self,
+        agent: AgentId,
+        terms: &[terminal::TerminalApp],
+    ) -> Option<terminal::TerminalApp> {
+        self.preferred_terminal
+            .get(&agent)
+            .copied()
+            .filter(|t| terms.contains(t))
+            .or_else(|| self.last_terminal.filter(|t| terms.contains(t)))
+            .or_else(|| terms.first().copied())
+    }
+
+    /// Open In 记忆持久化(prefs 表,key `open_in`):
+    /// `{"agents":{"claude-code":"claude-desktop",…},"last":"ghostty"}`。
+    /// 读取时按 id 对回本机已装终端——卸载/换平台后的残值静默丢弃
+    fn load_open_in_prefs(&mut self) {
+        let Some(raw) = self.store.pref_get("open_in") else {
+            return;
+        };
+        let Ok(prefs) = serde_json::from_str::<OpenInPrefs>(&raw) else {
+            return;
+        };
+        let by_id = |s: &str| {
+            terminal::installed_terminals()
+                .iter()
+                .find(|t| t.id() == s)
+                .copied()
+        };
+        for (k, val) in &prefs.agents {
+            if let (Some(agent), Some(term)) = (AgentId::from_str(k), by_id(val)) {
+                self.preferred_terminal.insert(agent, term);
+            }
+        }
+        self.last_terminal = prefs.last.as_deref().and_then(by_id);
+    }
+
+    fn save_open_in_prefs(&self) {
+        let prefs = OpenInPrefs {
+            agents: self
+                .preferred_terminal
+                .iter()
+                .map(|(a, t)| (a.as_str().to_string(), t.id().to_string()))
+                .collect(),
+            last: self.last_terminal.map(|t| t.id().to_string()),
+        };
+        if let Ok(raw) = serde_json::to_string(&prefs) {
+            let _ = self.store.pref_set("open_in", &raw);
+        }
+    }
+
+    /// per-agent 记忆任何点击都写(只影响本 agent,收敛到用户实际用的);
+    /// 全局 last_terminal 只在 explicit(下拉显式选择)时写——左段点的可能
+    /// 是回退值,写进全局会让一个 dsh 会话把 Kooky 偏好冲成 Terminal
     fn do_resume(
         &mut self,
         term: terminal::TerminalApp,
-        remember: bool,
+        explicit: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let Some(detail) = &self.detail else { return };
-        if remember {
-            self.preferred_terminal = Some(term);
-            cx.notify(); // split 按钮左段立即切到本次选择
+        self.preferred_terminal.insert(detail.meta.agent, term);
+        if explicit {
+            self.last_terminal = Some(term);
         }
+        self.save_open_in_prefs();
+        cx.notify(); // split 按钮左段立即切到本次选择
         let meta = detail.meta.clone();
         let task = cx.background_spawn(async move { terminal::resume_session_in(&meta, term) });
         Self::notify_when_done(window, cx, task, |outcome| {
@@ -5617,13 +5683,7 @@ impl Workbench {
                                         // 目标列表按 agent 过滤(Kooky 深链不认 dsh);
                                         // 偏好目标不在列表时(如 dsh 会话 + 偏好 Kooky)回退首项
                                         let terms = terminal::terminals_for(meta.agent);
-                                        let current = self
-                                            .preferred_terminal
-                                            .filter(|t| terms.contains(t))
-                                            .or_else(|| terms.first().copied());
-                                        // 偏好已存在时 current 要么就是它、要么是回退值,
-                                        // 两种情况点左段都不该改写偏好(见 do_resume)
-                                        let remember_current = self.preferred_terminal.is_none();
+                                        let current = self.open_in_target(meta.agent, &terms);
                                         let current_icon = current
                                             .and_then(|t| self.terminal_icons.get(t.id()).cloned());
                                         let term_items: Vec<(terminal::TerminalApp, Option<PathBuf>)> =
@@ -5653,15 +5713,13 @@ impl Workbench {
                                                     .cursor_pointer()
                                                     .hover(|s| s.bg(theme.secondary_hover))
                                                     .active(|s| s.bg(theme.secondary_active))
-                                                    .child(match &current_icon {
-                                                        Some(p) => img(p.clone())
-                                                            .size(px(14.))
-                                                            .into_any_element(),
-                                                        None => icon("icons/terminal.svg")
+                                                    .child(open_in_icon(
+                                                        current,
+                                                        current_icon.as_ref(),
+                                                        icon("icons/terminal.svg")
                                                             .with_size(px(13.))
-                                                            .text_color(theme.secondary_foreground)
-                                                            .into_any_element(),
-                                                    })
+                                                            .text_color(theme.secondary_foreground),
+                                                    ))
                                                     .tooltip({
                                                         let label: SharedString = match current {
                                                             Some(t) => format!("Open this session in {}", t.display_name()).into(),
@@ -5673,7 +5731,7 @@ impl Workbench {
                                                     })
                                                     .on_click(cx.listener(move |this, _, window, cx| {
                                                         if let Some(term) = current {
-                                                            this.do_resume(term, remember_current, window, cx);
+                                                            this.do_resume(term, false, window, cx);
                                                         } else {
                                                             // 空列表在 macOS 不可能(Terminal.app 恒在),
                                                             // Windows/Linux 上 PATH 被启动器改写时会发生
@@ -5719,14 +5777,12 @@ impl Workbench {
                                                                     h_flex()
                                                                         .gap(SPACE_SM)
                                                                         .items_center()
-                                                                        .child(match &icon_path {
-                                                                            Some(p) => img(p.clone())
-                                                                                .size(px(16.))
-                                                                                .into_any_element(),
-                                                                            None => icon("icons/terminal.svg")
-                                                                                .with_size(px(15.))
-                                                                                .into_any_element(),
-                                                                        })
+                                                                        .child(open_in_icon(
+                                                                            Some(term),
+                                                                            icon_path.as_ref(),
+                                                                            icon("icons/terminal.svg")
+                                                                                .with_size(px(15.)),
+                                                                        ))
                                                                         .child(term.display_name())
                                                                 })
                                                                 .on_click(move |_, window, cx| {
@@ -7555,6 +7611,31 @@ fn sidebar_row(
                     )))
                 }),
         )
+}
+
+/// Open In 记忆的落盘形态(prefs 表 `open_in`,id 字符串在加载时对回
+/// 本机已装终端,残值静默丢弃)
+#[derive(serde::Serialize, serde::Deserialize)]
+struct OpenInPrefs {
+    #[serde(default)]
+    agents: std::collections::BTreeMap<String, String>,
+    #[serde(default)]
+    last: Option<String>,
+}
+
+/// Open In 的目标图标:内嵌品牌覆盖(见 TerminalApp::brand_icon)→
+/// 提取的 .app 图标 → 通用终端 svg。两处渲染(split 左段/下拉)共用,
+/// 精度规则只此一份
+fn open_in_icon(
+    term: Option<terminal::TerminalApp>,
+    icon_path: Option<&PathBuf>,
+    fallback: Icon,
+) -> AnyElement {
+    match (term.and_then(|t| t.brand_icon()), icon_path) {
+        (Some(b), _) => img(b).size(px(16.)).into_any_element(),
+        (None, Some(p)) => img(p.clone()).size(px(16.)).into_any_element(),
+        (None, None) => fallback.into_any_element(),
+    }
 }
 
 /// 详情工具栏图标按钮。选中态 = 填充版图标 + 语义色(macOS 惯例),


### PR DESCRIPTION
Adds Claude Desktop and Codex Desktop as Open In deep-link targets, with duplicate-session protection on the Claude side and per-agent, persisted target memory.

## Highlights
- **Open in Claude Desktop / Codex Desktop**: Claude Code sessions deep-link via `claude://resume?session=`, Codex sessions via `codex://threads/` (ChatGPT.app verified by bundle id `com.openai.codex`)
- **No duplicate imports**: before deep-linking, Wake scans Claude Desktop's session index (including `priorCliSessionIds`; newest-mtime record wins across accounts) and sends the owning session's own uuid so Desktop focuses the existing session instead of importing a copy
- **Per-agent Open In memory**: each agent remembers its own target, with a global fallback for shell terminals; persisted in a new `prefs` KV table
- **Icon polish**: Codex Desktop shows the embedded Codex brand icon; split-button icon is 16px to match toolbar buttons

Reviewed via /simplify (4 angles, 9 fixes) and Codex review (3 P2s all fixed: priorCliSessionIds coverage, multi-account ambiguity, empty-id panic guard).

Release commit bumps the workspace to 0.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)