### PR TITLE
fix(macos): reopen main window when clicking dock icon after close

### DIFF
--- a/crates/wake/src/main.rs
+++ b/crates/wake/src/main.rs
@@ -24,8 +24,81 @@ use workbench::{
 
 actions!(wake_app, [Quit, CloseWindow]);
 
+// macOS:用户关掉最后一个窗后进程仍留 Dock,点 Dock 图标走 NSApplication 的
+// applicationShouldHandleReopen → gpui Platform::on_reopen。这里复用启动期
+// 的开窗配置,空窗重建、有窗只是把已存在的拉到前台,不重复实例
+fn open_main_window(cx: &mut App) -> anyhow::Result<WindowHandle<Root>> {
+    let bounds = Bounds::centered(None, size(px(1180.), px(760.)), cx);
+    // macOS:隐藏系统标题栏、内容顶到窗顶,traffic light 悬浮在侧栏上;
+    // Linux/Windows:标准系统标题栏(appears_transparent=false)。Windows
+    // 后端按此保留原生 caption(min/max/close、snap layouts、深色模式随
+    // 系统由 gpui 设 DWMWA_USE_IMMERSIVE_DARK_MODE),title 即窗名;
+    // GNOME Wayland 不给 SSD 时回落 CSD,见 window_decorations 注释。
+    // cfg! 而非 #[cfg]:两支在任一平台都参与类型检查,别让另一支只有 CI 见得到
+    let titlebar = if cfg!(target_os = "macos") {
+        TitlebarOptions {
+            title: None,
+            appears_transparent: true,
+            // 44px Wake 顶部净空中垂直居中 13.5px traffic lights。
+            traffic_light_position: Some(point(px(20.), px(15.))),
+        }
+    } else {
+        TitlebarOptions {
+            title: Some("Wake".into()),
+            appears_transparent: false,
+            traffic_light_position: None,
+        }
+    };
+    cx.open_window(
+        WindowOptions {
+            titlebar: Some(titlebar),
+            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            window_min_size: Some(size(px(940.), px(620.))),
+            // Linux 桌面按它归组窗口、匹配 .desktop(StartupWMClass=wake)
+            app_id: Some("wake".into()),
+            // Wayland 显式请求 CSD(2026-08-24 Codex review):默认的 Server
+            // 请求在 GNOME/Mutter(无 zxdg-decoration 协议)下会被 gpui 记成
+            // Server 而 compositor 实际什么都不画——窗口既无系统标题栏、
+            // workbench 又按 Server 不挂 TitleBar,彻底没有关窗/拖拽面。
+            // 请求 Client 后:Wayland 全家走 CSD(TitleBar 补位),X11 侧
+            // gpui 探测 compositor 不支持 CSD 时仍自动回报 Server(WM 标题
+            // 栏照常、TitleBar 不挂),macOS/Windows 忽略此字段(Windows
+            // 后端不实现 request_decorations,runtime 恒报 Server)
+            window_decorations: Some(WindowDecorations::Client),
+            ..Default::default()
+        },
+        |window, cx| {
+            // 跟随系统深浅色切换
+            window
+                .observe_window_appearance(|window, cx| {
+                    theme::sync_appearance(Some(window), cx);
+                })
+                .detach();
+            theme::sync_appearance(Some(window), cx);
+
+            let workbench = cx.new(|cx| Workbench::new(window, cx));
+            window.focus(&workbench.read(cx).focus_handle(cx), cx);
+            cx.new(|cx| Root::new(workbench, window, cx))
+        },
+    )
+}
+
 fn main() {
     let app = gpui_platform::application().with_assets(Assets);
+    // macOS:用户关掉最后一个窗后进程仍留 Dock,点 Dock 图标走 NSApplication 的
+    // applicationShouldHandleReopen → gpui Platform::on_reopen。空窗重建、
+    // 有窗只是把已存在的拉到前台,不重复实例
+    app.on_reopen(|cx| {
+        if cx.windows().is_empty() {
+            if let Err(e) = open_main_window(cx) {
+                wake_core::services::terminal::show_fatal_alert(&format!(
+                    "Wake couldn't reopen its window: {e}"
+                ));
+                std::process::exit(1);
+            }
+        }
+        cx.activate(true);
+    });
     app.run(move |cx: &mut App| {
         gpui_component::init(cx);
         gpui_component::set_locale("en");
@@ -74,59 +147,7 @@ fn main() {
             },
         ]);
 
-        let bounds = Bounds::centered(None, size(px(1180.), px(760.)), cx);
-        // macOS:隐藏系统标题栏、内容顶到窗顶,traffic light 悬浮在侧栏上;
-        // Linux/Windows:标准系统标题栏(appears_transparent=false)。Windows
-        // 后端按此保留原生 caption(min/max/close、snap layouts、深色模式随
-        // 系统由 gpui 设 DWMWA_USE_IMMERSIVE_DARK_MODE),title 即窗名;
-        // GNOME Wayland 不给 SSD 时回落 CSD,见 window_decorations 注释。
-        // cfg! 而非 #[cfg]:两支在任一平台都参与类型检查,别让另一支只有 CI 见得到
-        let titlebar = if cfg!(target_os = "macos") {
-            TitlebarOptions {
-                title: None,
-                appears_transparent: true,
-                // 44px Wake 顶部净空中垂直居中 13.5px traffic lights。
-                traffic_light_position: Some(point(px(20.), px(15.))),
-            }
-        } else {
-            TitlebarOptions {
-                title: Some("Wake".into()),
-                appears_transparent: false,
-                traffic_light_position: None,
-            }
-        };
-        let window = cx.open_window(
-            WindowOptions {
-                titlebar: Some(titlebar),
-                window_bounds: Some(WindowBounds::Windowed(bounds)),
-                window_min_size: Some(size(px(940.), px(620.))),
-                // Linux 桌面按它归组窗口、匹配 .desktop(StartupWMClass=wake)
-                app_id: Some("wake".into()),
-                // Wayland 显式请求 CSD(2026-08-24 Codex review):默认的 Server
-                // 请求在 GNOME/Mutter(无 zxdg-decoration 协议)下会被 gpui 记成
-                // Server 而 compositor 实际什么都不画——窗口既无系统标题栏、
-                // workbench 又按 Server 不挂 TitleBar,彻底没有关窗/拖拽面。
-                // 请求 Client 后:Wayland 全家走 CSD(TitleBar 补位),X11 侧
-                // gpui 探测 compositor 不支持 CSD 时仍自动回报 Server(WM 标题
-                // 栏照常、TitleBar 不挂),macOS/Windows 忽略此字段(Windows
-                // 后端不实现 request_decorations,runtime 恒报 Server)
-                window_decorations: Some(WindowDecorations::Client),
-                ..Default::default()
-            },
-            |window, cx| {
-                // 跟随系统深浅色切换
-                window
-                    .observe_window_appearance(|window, cx| {
-                        theme::sync_appearance(Some(window), cx);
-                    })
-                    .detach();
-                theme::sync_appearance(Some(window), cx);
-
-                let workbench = cx.new(|cx| Workbench::new(window, cx));
-                window.focus(&workbench.read(cx).focus_handle(cx), cx);
-                cx.new(|cx| Root::new(workbench, window, cx))
-            },
-        );
+        let window = open_main_window(cx);
         // 开窗失败必须自己报:release 的 Windows 子系统没有 stderr,panic
         // 消息无处可去,用户看到的就是任务栏闪一下然后什么都没有
         //(GPU/驱动起不来、RDP 会话等都会走到这)。show_fatal_alert 会弹


### PR DESCRIPTION
> 验证：[v0.3.5Test](https://github.com/MiQieR/Wake/releases/tag/v0.3.5Test) macOS 安装包本地手测通过，Dock 图标点击行为已恢复。

---

## 问题

macOS 不会在最后一个窗口关闭后退出 Wake 进程（预期行为，应用继续留在 Dock 中）。但是点击 Dock 图标本来应该把主窗口重新打开，原实现却没有任何响应——必须完全退出再重新启动 Wake 才能看到窗口。

## 原因

gpui 的 `Platform` trait 提供了一个 `on_reopen` 回调（`Application::on_reopen`），对应 macOS 的 `applicationShouldHandleReopen:hasVisibleWindows:`。原代码既没有注册这个回调，也没有在窗口被移除后重新打开窗口的逻辑，所以 Dock 图标点击变成了静默的 no-op。

## 修复

把启动期构造主窗口的代码抽成 `open_main_window(cx)` 辅助函数，然后在 `Application` 上注册 `on_reopen`：

- **没有窗口时**（用户关了红钮、Dock 图标再次点击）：复用同一份配置重建主窗口
- **有窗口时**（窗口最小化、多实例切换）：只调用 `cx.activate(true)` 把已存在的窗口拉到前台，避免重复创建实例

开窗失败仍然走 `wake-core::services::terminal::show_fatal_alert` 系统对话框，与原启动流程的错误处理一致。`CloseWindow` 动作（cmd-W / File 菜单）保持原行为不变——只有 macOS 的 Dock 重开这条路径被接上。

## 改动

- `crates/wake/src/main.rs`：抽出 `open_main_window` 辅助函数 + 注册 `Application::on_reopen`（+74 / −53）
- 仅影响主进程入口，不修改 workbench、settings、wake-core 等任何下游模块

## 验证

- 已通过 [v0.3.5Test](https://github.com/MiQieR/Wake/releases/tag/v0.3.5Test) macOS 安装包本地手测
- 行为契约：
  - macOS：红钮关窗 → Dock 点击 → 主窗口重现 ✅
  - macOS：窗口最小化 → Dock 点击 → 窗口恢复并聚焦 ✅
  - macOS：app 已隐藏（cmd-H）→ Dock 点击 → 窗口恢复并聚焦 ✅
  - Linux/Windows：`on_reopen` 在这两平台是空操作，原行为不变 ✅
  - 启动失败（GPU/RDP 会话等）依然弹 `show_fatal_alert` 并退出 ✅

---

## Problem

On macOS, closing the last Wake window does not terminate the process — that's expected, the app remains in the Dock. But clicking the Dock icon should bring the main window back, and the previous build silently ignored that gesture. Users had to fully quit and relaunch Wake to see a window again.

## Root cause

gpui's `Platform` trait exposes an `on_reopen` hook (`Application::on_reopen`) that wires up to macOS's `applicationShouldHandleReopen:hasVisibleWindows:`. Wake never registered a handler and had no path to recreate a window after `Window::remove_window()` was called from the close button, so the Dock click became a silent no-op.

## Fix

Extract the launch-time window setup into `open_main_window(cx)` and register `Application::on_reopen`:

- **No windows** (user closed the red button, then clicked the Dock): reuse the exact same config to recreate the main window
- **Windows exist** (window minimized, or jumping between instances): just call `cx.activate(true)` to bring the existing window forward — no duplicate Workbench instance

Window creation failures still fall through to `wake-core::services::terminal::show_fatal_alert` + `process::exit(1)`, matching the startup error path. The existing `CloseWindow` action (cmd-W / File menu) keeps its current `remove_window()` semantics — only the Dock-reopen path gets new behavior.

## Changes

- `crates/wake/src/main.rs`: extracted `open_main_window` helper + registered `Application::on_reopen` (+74 / −53)
- Only touches the process entry point — no changes to workbench, settings, wake-core, or any downstream module

## Verification

- Manually verified on macOS via the [v0.3.5Test](https://github.com/MiQieR/Wake/releases/tag/v0.3.5Test) installer built by the existing GitHub Action
- Behavioral contract:
  - macOS: red button close → Dock click → main window returns ✅
  - macOS: window minimized → Dock click → window restored and focused ✅
  - macOS: app hidden (cmd-H) → Dock click → window restored and focused ✅
  - Linux/Windows: `on_reopen` is a no-op on these platforms, behavior unchanged ✅
  - Startup failure (GPU / RDP session) still shows `show_fatal_alert` and exits ✅